### PR TITLE
Add analysis for the cursor scale factor calculated in load_all_cursors.

### DIFF
--- a/tests/compare/12010-32.txt
+++ b/tests/compare/12010-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[10575ec]
 current_tooltip_ctrl: Mem32[e476d4]
 cursor_marker: Mem32[daacb4]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[e81f48]
 dcreep_list_begin: 1057540
 dcreep_list_size: 1057568

--- a/tests/compare/12011-32.txt
+++ b/tests/compare/12011-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[103489c]
 current_tooltip_ctrl: Mem32[e2498c]
 cursor_marker: Mem32[d87f64]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[e5f200]
 dcreep_list_begin: 10347f0
 dcreep_list_size: 1034818

--- a/tests/compare/12011b-32.txt
+++ b/tests/compare/12011b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[11348a4]
 current_tooltip_ctrl: Mem32[f2498c]
 cursor_marker: Mem32[e87f64]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[f5f200]
 dcreep_list_begin: 11347f8
 dcreep_list_size: 1134820

--- a/tests/compare/1207-32.txt
+++ b/tests/compare/1207-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[1146d3c]
 current_tooltip_ctrl: Mem32[f36ed4]
 cursor_marker: Mem32[e9a52c]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[f71748]
 dcreep_list_begin: 1146c90
 dcreep_list_size: 1146cb8

--- a/tests/compare/1208-32.txt
+++ b/tests/compare/1208-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[1145774]
 current_tooltip_ctrl: Mem32[f3591c]
 cursor_marker: Mem32[e98f7c]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[f70190]
 dcreep_list_begin: 11456c8
 dcreep_list_size: 11456f0

--- a/tests/compare/1209-32.txt
+++ b/tests/compare/1209-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[1053d1c]
 current_tooltip_ctrl: Mem32[e43e9c]
 cursor_marker: Mem32[da7504]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[e7e718]
 dcreep_list_begin: 1053c70
 dcreep_list_size: 1053c98

--- a/tests/compare/1209b-32.txt
+++ b/tests/compare/1209b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[105bcfc]
 current_tooltip_ctrl: Mem32[e4bea4]
 cursor_marker: Mem32[daf504]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[e86718]
 dcreep_list_begin: 105bc50
 dcreep_list_size: 105bc78

--- a/tests/compare/1210-32.txt
+++ b/tests/compare/1210-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[f6f17c]
 current_tooltip_ctrl: Mem32[d6410c]
 cursor_marker: Mem32[d6379c]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[d97488]
 dcreep_list_begin: f6f0d0
 dcreep_list_size: f6f0f8

--- a/tests/compare/1210b-32.txt
+++ b/tests/compare/1210b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[f541b4]
 current_tooltip_ctrl: Mem32[d4914c]
 cursor_marker: Mem32[d487ec]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[d7c4c0]
 dcreep_list_begin: f54108
 dcreep_list_size: f54130

--- a/tests/compare/1211-32.txt
+++ b/tests/compare/1211-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[1090bf4]
 current_tooltip_ctrl: Mem32[e857d4]
 cursor_marker: Mem32[e84e64]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[eb8b50]
 dcreep_list_begin: 1090b48
 dcreep_list_size: 1090b70

--- a/tests/compare/1211b-32.txt
+++ b/tests/compare/1211b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[fc2cf4]
 current_tooltip_ctrl: Mem32[db78b4]
 cursor_marker: Mem32[db6f4c]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[deac30]
 dcreep_list_begin: fc2c48
 dcreep_list_size: fc2c70

--- a/tests/compare/1212-32.txt
+++ b/tests/compare/1212-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[f490cc]
 current_tooltip_ctrl: Mem32[d3d560]
 cursor_marker: Mem32[d3d1f4]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[d708e0]
 dcreep_list_begin: f49020
 dcreep_list_size: f49048

--- a/tests/compare/1212b-32.txt
+++ b/tests/compare/1212b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[ee2164]
 current_tooltip_ctrl: Mem32[cd65cc]
 cursor_marker: Mem32[cd6264]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[d09948]
 dcreep_list_begin: ee20b8
 dcreep_list_size: ee20e0

--- a/tests/compare/1213-32.txt
+++ b/tests/compare/1213-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[ecebd4]
 current_tooltip_ctrl: Mem32[cc2e34]
 cursor_marker: Mem32[cc2abc]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[cf61c0]
 dcreep_list_begin: eceb28
 dcreep_list_size: eceb50

--- a/tests/compare/1213b-32.txt
+++ b/tests/compare/1213b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[ec9bdc]
 current_tooltip_ctrl: Mem32[cbde28]
 cursor_marker: Mem32[cbdabc]
+cursor_scale_factor: None
 dat_requirement_error: Mem32[cf11b0]
 dcreep_list_begin: ec9b30
 dcreep_list_size: ec9b58

--- a/tests/compare/1214-32.txt
+++ b/tests/compare/1214-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[ed9134]
 current_tooltip_ctrl: Mem32[ccd3cc]
 cursor_marker: Mem32[ccd074]
+cursor_scale_factor: Mem32[e86de8]
 dat_requirement_error: Mem32[d00760]
 dcreep_list_begin: ed9088
 dcreep_list_size: ed90b0

--- a/tests/compare/1214b-32.txt
+++ b/tests/compare/1214b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[eb1134]
 current_tooltip_ctrl: Mem32[ca53c4]
 cursor_marker: Mem32[ca505c]
+cursor_scale_factor: Mem32[e5ede0]
 dat_requirement_error: Mem32[cd8750]
 dcreep_list_begin: eb1088
 dcreep_list_size: eb10b0

--- a/tests/compare/1214c-32.txt
+++ b/tests/compare/1214c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[eac14c]
 current_tooltip_ctrl: Mem32[ca03d8]
 cursor_marker: Mem32[ca0064]
+cursor_scale_factor: Mem32[e59df0]
 dat_requirement_error: Mem32[cd3760]
 dcreep_list_begin: eac0a0
 dcreep_list_size: eac0c8

--- a/tests/compare/1215-32.txt
+++ b/tests/compare/1215-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[f12374]
 current_tooltip_ctrl: Mem32[d065dc]
 cursor_marker: Mem32[d06284]
+cursor_scale_factor: Mem32[ebfff8]
 dat_requirement_error: Mem32[d39968]
 dcreep_list_begin: f122c8
 dcreep_list_size: f122f0

--- a/tests/compare/1215b-32.txt
+++ b/tests/compare/1215b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[f2a324]
 current_tooltip_ctrl: Mem32[d1e5a8]
 cursor_marker: Mem32[d1e234]
+cursor_scale_factor: Mem32[ed7fc0]
 dat_requirement_error: Mem32[d51930]
 dcreep_list_begin: f2a278
 dcreep_list_size: f2a2a0

--- a/tests/compare/1215c-32.txt
+++ b/tests/compare/1215c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[f3235c]
 current_tooltip_ctrl: Mem32[d265dc]
 cursor_marker: Mem32[d26254]
+cursor_scale_factor: Mem32[edfff8]
 dat_requirement_error: Mem32[d59968]
 dcreep_list_begin: f322b0
 dcreep_list_size: f322d8

--- a/tests/compare/1215d-32.txt
+++ b/tests/compare/1215d-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[f11334]
 current_tooltip_ctrl: Mem32[d055b4]
 cursor_marker: Mem32[d05234]
+cursor_scale_factor: Mem32[ebefd0]
 dat_requirement_error: Mem32[d38940]
 dcreep_list_begin: f11288
 dcreep_list_size: f112b0

--- a/tests/compare/1215e-32.txt
+++ b/tests/compare/1215e-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[efe2e4]
 current_tooltip_ctrl: Mem32[cf2564]
 cursor_marker: Mem32[cf2214]
+cursor_scale_factor: Mem32[eabf80]
 dat_requirement_error: Mem32[d258f0]
 dcreep_list_begin: efe238
 dcreep_list_size: efe260

--- a/tests/compare/1215f-32.txt
+++ b/tests/compare/1215f-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[efe2e4]
 current_tooltip_ctrl: Mem32[cf2564]
 cursor_marker: Mem32[cf2214]
+cursor_scale_factor: Mem32[eabf80]
 dat_requirement_error: Mem32[d258f0]
 dcreep_list_begin: efe238
 dcreep_list_size: efe260

--- a/tests/compare/1215g-32.txt
+++ b/tests/compare/1215g-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[ef9344]
 current_tooltip_ctrl: Mem32[ced58c]
 cursor_marker: Mem32[ced1fc]
+cursor_scale_factor: Mem32[ea6fd8]
 dat_requirement_error: Mem32[d20948]
 dcreep_list_begin: ef9298
 dcreep_list_size: ef92c0

--- a/tests/compare/1215h-32.txt
+++ b/tests/compare/1215h-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[f31384]
 current_tooltip_ctrl: Mem32[d255b4]
 cursor_marker: Mem32[d25230]
+cursor_scale_factor: Mem32[edf008]
 dat_requirement_error: Mem32[d58978]
 dcreep_list_begin: f312d8
 dcreep_list_size: f31300

--- a/tests/compare/1215i-32.txt
+++ b/tests/compare/1215i-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[f413fc]
 current_tooltip_ctrl: Mem32[d357e8]
 cursor_marker: Mem32[d35444]
+cursor_scale_factor: Mem32[eef1f0]
 dat_requirement_error: Mem32[d68b60]
 dcreep_list_begin: f41350
 dcreep_list_size: f41378

--- a/tests/compare/1220-32.txt
+++ b/tests/compare/1220-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[fde1c4]
 current_tooltip_ctrl: Mem32[dd1244]
 cursor_marker: Mem32[dd0eac]
+cursor_scale_factor: Mem32[f8ac68]
 dat_requirement_error: Mem32[e045d8]
 dcreep_list_begin: fde118
 dcreep_list_size: fde140

--- a/tests/compare/1220b-32.txt
+++ b/tests/compare/1220b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[fe21a4]
 current_tooltip_ctrl: Mem32[dd5228]
 cursor_marker: Mem32[dd4ebc]
+cursor_scale_factor: Mem32[f8ec48]
 dat_requirement_error: Mem32[e085b8]
 dcreep_list_begin: fe20f8
 dcreep_list_size: fe2120

--- a/tests/compare/1220c-32.txt
+++ b/tests/compare/1220c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[fe3194]
 current_tooltip_ctrl: Mem32[dd6220]
 cursor_marker: Mem32[dd5eac]
+cursor_scale_factor: Mem32[f8fc40]
 dat_requirement_error: Mem32[e095b0]
 dcreep_list_begin: fe30e8
 dcreep_list_size: fe3110

--- a/tests/compare/1220d-32.txt
+++ b/tests/compare/1220d-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[fe81bc]
 current_tooltip_ctrl: Mem32[ddb240]
 cursor_marker: Mem32[ddae94]
+cursor_scale_factor: Mem32[f94c60]
 dat_requirement_error: Mem32[e0e5d0]
 dcreep_list_begin: fe8110
 dcreep_list_size: fe8138

--- a/tests/compare/1220e-32.txt
+++ b/tests/compare/1220e-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[10116e4]
 current_tooltip_ctrl: Mem32[e05210]
 cursor_marker: Mem32[e04e7c]
+cursor_scale_factor: Mem32[fbec30]
 dat_requirement_error: Mem32[e385a0]
 dcreep_list_begin: 1011638
 dcreep_list_size: 1011660

--- a/tests/compare/1220f-32.txt
+++ b/tests/compare/1220f-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[fe9a8c]
 current_tooltip_ctrl: Mem32[ddd57c]
 cursor_marker: Mem32[ddd1f4]
+cursor_scale_factor: Mem32[f96fa0]
 dat_requirement_error: Mem32[e10910]
 dcreep_list_begin: fe99e0
 dcreep_list_size: fe9a08

--- a/tests/compare/1220g-32.txt
+++ b/tests/compare/1220g-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[100faa4]
 current_tooltip_ctrl: Mem32[e035e0]
 cursor_marker: Mem32[e0325c]
+cursor_scale_factor: Mem32[fbd000]
 dat_requirement_error: Mem32[e36970]
 dcreep_list_begin: 100f9f8
 dcreep_list_size: 100fa20

--- a/tests/compare/1220h-32.txt
+++ b/tests/compare/1220h-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[ffd284]
 current_tooltip_ctrl: Mem32[df0db0]
 cursor_marker: Mem32[df0a44]
+cursor_scale_factor: Mem32[faa7c8]
 dat_requirement_error: Mem32[e24138]
 dcreep_list_begin: ffd1d8
 dcreep_list_size: ffd200

--- a/tests/compare/1221-32.txt
+++ b/tests/compare/1221-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[10bdb8c]
 current_tooltip_ctrl: Mem32[eb0cac]
 cursor_marker: Mem32[eb05ec]
+cursor_scale_factor: Mem32[106aa78]
 dat_requirement_error: Mem32[ee422c]
 dcreep_list_begin: 10bdac8
 dcreep_list_size: 10bdaf0

--- a/tests/compare/1221b-32.txt
+++ b/tests/compare/1221b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[1079ba4]
 current_tooltip_ctrl: Mem32[e6cccc]
 cursor_marker: Mem32[e6c604]
+cursor_scale_factor: Mem32[1026a90]
 dat_requirement_error: Mem32[ea0244]
 dcreep_list_begin: 1079ae0
 dcreep_list_size: 1079b08

--- a/tests/compare/1221c-32.txt
+++ b/tests/compare/1221c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[108ab94]
 current_tooltip_ctrl: Mem32[e7dcdc]
 cursor_marker: Mem32[e7d62c]
+cursor_scale_factor: Mem32[1037a80]
 dat_requirement_error: Mem32[eb1254]
 dcreep_list_begin: 108aad0
 dcreep_list_size: 108aaf8

--- a/tests/compare/1222-32.txt
+++ b/tests/compare/1222-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[ffbe7c]
 current_tooltip_ctrl: Mem32[deef5c]
 cursor_marker: Mem32[dee878]
+cursor_scale_factor: Mem32[fa8d00]
 dat_requirement_error: Mem32[e224dc]
 dcreep_list_begin: ffbdb8
 dcreep_list_size: ffbde0

--- a/tests/compare/1222b-32.txt
+++ b/tests/compare/1222b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[1002e8c]
 current_tooltip_ctrl: Mem32[df5f84]
 cursor_marker: Mem32[df5898]
+cursor_scale_factor: Mem32[fafd30]
 dat_requirement_error: Mem32[e2950c]
 dcreep_list_begin: 1002dc8
 dcreep_list_size: 1002df0

--- a/tests/compare/1222c-32.txt
+++ b/tests/compare/1222c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[102de6c]
 current_tooltip_ctrl: Mem32[e20f8c]
 cursor_marker: Mem32[e20898]
+cursor_scale_factor: Mem32[fdad30]
 dat_requirement_error: Mem32[e5450c]
 dcreep_list_begin: 102dda8
 dcreep_list_size: 102ddd0

--- a/tests/compare/1222d-32.txt
+++ b/tests/compare/1222d-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[100cb34]
 current_tooltip_ctrl: Mem32[dffc44]
 cursor_marker: Mem32[dff538]
+cursor_scale_factor: Mem32[fb99f0]
 dat_requirement_error: Mem32[e331c4]
 dcreep_list_begin: 100ca70
 dcreep_list_size: 100ca98

--- a/tests/compare/1223-32.txt
+++ b/tests/compare/1223-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[ffb684]
 current_tooltip_ctrl: Mem32[decf4c]
 cursor_marker: Mem32[dec870]
+cursor_scale_factor: Mem32[fa8538]
 dat_requirement_error: Mem32[e21d0c]
 dcreep_list_begin: ffb5c0
 dcreep_list_size: ffb5e8

--- a/tests/compare/1223_ptr1-32.txt
+++ b/tests/compare/1223_ptr1-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[fec65c]
 current_tooltip_ctrl: Mem32[dddf4c]
 cursor_marker: Mem32[ddd870]
+cursor_scale_factor: Mem32[f99520]
 dat_requirement_error: Mem32[e12cf4]
 dcreep_list_begin: fec598
 dcreep_list_size: fec5c0

--- a/tests/compare/1223b-32.txt
+++ b/tests/compare/1223b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[101e694]
 current_tooltip_ctrl: Mem32[e0ff64]
 cursor_marker: Mem32[e0f8a8]
+cursor_scale_factor: Mem32[fcb548]
 dat_requirement_error: Mem32[e44d1c]
 dcreep_list_begin: 101e5d0
 dcreep_list_size: 101e5f8

--- a/tests/compare/1223c-32.txt
+++ b/tests/compare/1223c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[105568c]
 current_tooltip_ctrl: Mem32[e46f6c]
 cursor_marker: Mem32[e468a0]
+cursor_scale_factor: Mem32[1002548]
 dat_requirement_error: Mem32[e7bd24]
 dcreep_list_begin: 10555c8
 dcreep_list_size: 10555f0

--- a/tests/compare/1223d-32.txt
+++ b/tests/compare/1223d-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[10236a4]
 current_tooltip_ctrl: Mem32[e14f84]
 cursor_marker: Mem32[e148c0]
+cursor_scale_factor: Mem32[fd0560]
 dat_requirement_error: Mem32[e49d3c]
 dcreep_list_begin: 10235e0
 dcreep_list_size: 1023608

--- a/tests/compare/1223e-32.txt
+++ b/tests/compare/1223e-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[103f6bc]
 current_tooltip_ctrl: Mem32[e30f84]
 cursor_marker: Mem32[e308c8]
+cursor_scale_factor: Mem32[fec568]
 dat_requirement_error: Mem32[e65d3c]
 dcreep_list_begin: 103f5f8
 dcreep_list_size: 103f620

--- a/tests/compare/1224-32.txt
+++ b/tests/compare/1224-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[1037f94]
 current_tooltip_ctrl: Mem32[e29834]
 cursor_marker: Mem32[e29158]
+cursor_scale_factor: Mem32[fe4e30]
 dat_requirement_error: Mem32[e5e5e4]
 dcreep_list_begin: 1037ed0
 dcreep_list_size: 1037ef8

--- a/tests/compare/1224b-32.txt
+++ b/tests/compare/1224b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[1049b1c]
 current_tooltip_ctrl: Mem32[e3b32c]
 cursor_marker: Mem32[e3ac50]
+cursor_scale_factor: Mem32[ff6928]
 dat_requirement_error: Mem32[e700dc]
 dcreep_list_begin: 1049a58
 dcreep_list_size: 1049a80

--- a/tests/compare/1224c-32.txt
+++ b/tests/compare/1224c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: None
 current_campaign_mission: Mem32[1003b24]
 current_tooltip_ctrl: Mem32[df5334]
 cursor_marker: Mem32[df4c50]
+cursor_scale_factor: Mem32[fb0930]
 dat_requirement_error: Mem32[e2a0e4]
 dcreep_list_begin: 1003a60
 dcreep_list_size: 1003a88

--- a/tests/compare/1230a-32.txt
+++ b/tests/compare/1230a-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[1012b6c]
 current_campaign_mission: Mem32[ff1f7c]
 current_tooltip_ctrl: Mem32[ddf468]
 cursor_marker: Mem32[ddf0c4]
+cursor_scale_factor: Mem32[f9fe90]
 dat_requirement_error: Mem32[e19918]
 dcreep_list_begin: ff1ed0
 dcreep_list_size: ff1ef8

--- a/tests/compare/1230a-64.txt
+++ b/tests/compare/1230a-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140ec1c38]
 current_campaign_mission: Mem64[140e9da70]
 current_tooltip_ctrl: Mem64[140c677b8]
 cursor_marker: Mem64[140c67178]
+cursor_scale_factor: Mem32[140e418dc]
 dat_requirement_error: Mem32[140cbb158]
 dcreep_list_begin: 140e9d960
 dcreep_list_size: 140e9d9b0

--- a/tests/compare/1230b-32.txt
+++ b/tests/compare/1230b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[102db54]
 current_campaign_mission: Mem32[100cf64]
 current_tooltip_ctrl: Mem32[dfa450]
 cursor_marker: Mem32[dfa0bc]
+cursor_scale_factor: Mem32[fbae78]
 dat_requirement_error: Mem32[e34900]
 dcreep_list_begin: 100ceb8
 dcreep_list_size: 100cee0

--- a/tests/compare/1230b-64.txt
+++ b/tests/compare/1230b-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140e97c68]
 current_campaign_mission: Mem64[140e73aa0]
 current_tooltip_ctrl: Mem64[140c3d7d8]
 cursor_marker: Mem64[140c3d198]
+cursor_scale_factor: Mem32[140e1790c]
 dat_requirement_error: Mem32[140c91188]
 dcreep_list_begin: 140e73990
 dcreep_list_size: 140e739e0

--- a/tests/compare/1230c-32.txt
+++ b/tests/compare/1230c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[1008b64]
 current_campaign_mission: Mem32[fe7f74]
 current_tooltip_ctrl: Mem32[dd5458]
 cursor_marker: Mem32[dd50bc]
+cursor_scale_factor: Mem32[f95e80]
 dat_requirement_error: Mem32[e0f908]
 dcreep_list_begin: fe7ec8
 dcreep_list_size: fe7ef0

--- a/tests/compare/1230c-64.txt
+++ b/tests/compare/1230c-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140eb7c68]
 current_campaign_mission: Mem64[140e93aa0]
 current_tooltip_ctrl: Mem64[140c5d7d0]
 cursor_marker: Mem64[140c5d198]
+cursor_scale_factor: Mem32[140e378fc]
 dat_requirement_error: Mem32[140cb1178]
 dcreep_list_begin: 140e93990
 dcreep_list_size: 140e939e0

--- a/tests/compare/1230d-32.txt
+++ b/tests/compare/1230d-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[1038a14]
 current_campaign_mission: Mem32[1017e24]
 current_tooltip_ctrl: Mem32[e052c0]
 cursor_marker: Mem32[e04f2c]
+cursor_scale_factor: Mem32[fc5d08]
 dat_requirement_error: Mem32[e3f778]
 dcreep_list_begin: 1017d78
 dcreep_list_size: 1017da0

--- a/tests/compare/1230d-64.txt
+++ b/tests/compare/1230d-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140eb3b08]
 current_campaign_mission: Mem64[140e8f940]
 current_tooltip_ctrl: Mem64[140c59600]
 cursor_marker: Mem64[140c58fc8]
+cursor_scale_factor: Mem32[140e3374c]
 dat_requirement_error: Mem32[140cacf98]
 dcreep_list_begin: 140e8f830
 dcreep_list_size: 140e8f880

--- a/tests/compare/1230e-32.txt
+++ b/tests/compare/1230e-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[1050a1c]
 current_campaign_mission: Mem32[102fe2c]
 current_tooltip_ctrl: Mem32[e1d2c8]
 cursor_marker: Mem32[e1cf34]
+cursor_scale_factor: Mem32[fddd08]
 dat_requirement_error: Mem32[e57778]
 dcreep_list_begin: 102fd80
 dcreep_list_size: 102fda8

--- a/tests/compare/1230e-64.txt
+++ b/tests/compare/1230e-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140ebbb18]
 current_campaign_mission: Mem64[140e97950]
 current_tooltip_ctrl: Mem64[140c61610]
 cursor_marker: Mem64[140c60fd8]
+cursor_scale_factor: Mem32[140e3b75c]
 dat_requirement_error: Mem32[140cb4fa8]
 dcreep_list_begin: 140e97840
 dcreep_list_size: 140e97890

--- a/tests/compare/1230f-32.txt
+++ b/tests/compare/1230f-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[100fa1c]
 current_campaign_mission: Mem32[feee2c]
 current_tooltip_ctrl: Mem32[ddc2c8]
 cursor_marker: Mem32[ddbf2c]
+cursor_scale_factor: Mem32[f9cd08]
 dat_requirement_error: Mem32[e16778]
 dcreep_list_begin: feed80
 dcreep_list_size: feeda8

--- a/tests/compare/1230f-64.txt
+++ b/tests/compare/1230f-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140eabb18]
 current_campaign_mission: Mem64[140e87950]
 current_tooltip_ctrl: Mem64[140c515f0]
 cursor_marker: Mem64[140c50fb8]
+cursor_scale_factor: Mem32[140e2b74c]
 dat_requirement_error: Mem32[140ca4f98]
 dcreep_list_begin: 140e87840
 dcreep_list_size: 140e87890

--- a/tests/compare/1230g-32.txt
+++ b/tests/compare/1230g-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[104e2f4]
 current_campaign_mission: Mem32[102d6fc]
 current_tooltip_ctrl: Mem32[e1aba0]
 cursor_marker: Mem32[e1a7fc]
+cursor_scale_factor: Mem32[fdb5e0]
 dat_requirement_error: Mem32[e55050]
 dcreep_list_begin: 102d650
 dcreep_list_size: 102d678

--- a/tests/compare/1230g-64.txt
+++ b/tests/compare/1230g-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140ec8588]
 current_campaign_mission: Mem64[140ea43c0]
 current_tooltip_ctrl: Mem64[140c6e060]
 cursor_marker: Mem64[140c6da18]
+cursor_scale_factor: Mem32[140e481bc]
 dat_requirement_error: Mem32[140cc1a08]
 dcreep_list_begin: 140ea42b0
 dcreep_list_size: 140ea4300

--- a/tests/compare/1230h-32.txt
+++ b/tests/compare/1230h-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[103690c]
 current_campaign_mission: Mem32[1015f14]
 current_tooltip_ctrl: Mem32[e02bb0]
 cursor_marker: Mem32[e0281c]
+cursor_scale_factor: Mem32[fc3df0]
 dat_requirement_error: Mem32[e3d860]
 dcreep_list_begin: 1015e68
 dcreep_list_size: 1015e90

--- a/tests/compare/1230h-64.txt
+++ b/tests/compare/1230h-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140ed6b98]
 current_campaign_mission: Mem64[140eb2bd0]
 current_tooltip_ctrl: Mem64[140c7c078]
 cursor_marker: Mem64[140c7ba38]
+cursor_scale_factor: Mem32[140e569cc]
 dat_requirement_error: Mem32[140cd0218]
 dcreep_list_begin: 140eb2ac0
 dcreep_list_size: 140eb2b10

--- a/tests/compare/1230i-32.txt
+++ b/tests/compare/1230i-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[103f91c]
 current_campaign_mission: Mem32[101ef24]
 current_tooltip_ctrl: Mem32[e0bbb8]
 cursor_marker: Mem32[e0b81c]
+cursor_scale_factor: Mem32[fcce00]
 dat_requirement_error: Mem32[e46870]
 dcreep_list_begin: 101ee78
 dcreep_list_size: 101eea0

--- a/tests/compare/1230i-64.txt
+++ b/tests/compare/1230i-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140eedb98]
 current_campaign_mission: Mem64[140ec9bd0]
 current_tooltip_ctrl: Mem64[140c93088]
 cursor_marker: Mem64[140c92a38]
+cursor_scale_factor: Mem32[140e6d9dc]
 dat_requirement_error: Mem32[140ce7228]
 dcreep_list_begin: 140ec9ac0
 dcreep_list_size: 140ec9b10

--- a/tests/compare/1230j-32.txt
+++ b/tests/compare/1230j-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[1025c44]
 current_campaign_mission: Mem32[100524c]
 current_tooltip_ctrl: Mem32[df1d90]
 cursor_marker: Mem32[df19fc]
+cursor_scale_factor: Mem32[fb3058]
 dat_requirement_error: Mem32[e2ca58]
 dcreep_list_begin: 10051a0
 dcreep_list_size: 10051c8

--- a/tests/compare/1230j-64.txt
+++ b/tests/compare/1230j-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140ef10c8]
 current_campaign_mission: Mem64[140ecd100]
 current_tooltip_ctrl: Mem64[140c963b0]
 cursor_marker: Mem64[140c95d68]
+cursor_scale_factor: Mem32[140e70d6c]
 dat_requirement_error: Mem32[140cea578]
 dcreep_list_begin: 140eccff0
 dcreep_list_size: 140ecd040

--- a/tests/compare/1231a-32.txt
+++ b/tests/compare/1231a-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[1065d2c]
 current_campaign_mission: Mem32[104661c]
 current_tooltip_ctrl: Mem32[e32590]
 cursor_marker: Mem32[e3211c]
+cursor_scale_factor: Mem32[ff43d0]
 dat_requirement_error: Mem32[e6ddd0]
 dcreep_list_begin: 1046570
 dcreep_list_size: 1046598

--- a/tests/compare/1231a-64.txt
+++ b/tests/compare/1231a-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140e89f28]
 current_campaign_mission: Mem64[140e67340]
 current_tooltip_ctrl: Mem64[140c2f9d8]
 cursor_marker: Mem64[140c2f2a8]
+cursor_scale_factor: Mem32[140e0aefc]
 dat_requirement_error: Mem32[140c84708]
 dcreep_list_begin: 140e67230
 dcreep_list_size: 140e67280

--- a/tests/compare/1232a-32.txt
+++ b/tests/compare/1232a-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[10e532c]
 current_campaign_mission: Mem32[10c5848]
 current_tooltip_ctrl: Mem32[eb1798]
 cursor_marker: Mem32[eb130c]
+cursor_scale_factor: Mem32[10735c8]
 dat_requirement_error: Mem32[eecfc8]
 dcreep_list_begin: 10c5798
 dcreep_list_size: 10c57c0

--- a/tests/compare/1232a-64.txt
+++ b/tests/compare/1232a-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f59118]
 current_campaign_mission: Mem64[140f36128]
 current_tooltip_ctrl: Mem64[140cfe768]
 cursor_marker: Mem64[140cfe038]
+cursor_scale_factor: Mem32[140ed9c9c]
 dat_requirement_error: Mem32[140d534a8]
 dcreep_list_begin: 140f36010
 dcreep_list_size: 140f36060

--- a/tests/compare/1232b-32.txt
+++ b/tests/compare/1232b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[10dd41c]
 current_campaign_mission: Mem32[10bd938]
 current_tooltip_ctrl: Mem32[ea9888]
 cursor_marker: Mem32[ea940c]
+cursor_scale_factor: Mem32[106b6b8]
 dat_requirement_error: Mem32[ee50b8]
 dcreep_list_begin: 10bd888
 dcreep_list_size: 10bd8b0

--- a/tests/compare/1232b-64.txt
+++ b/tests/compare/1232b-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f44228]
 current_campaign_mission: Mem64[140f21238]
 current_tooltip_ctrl: Mem64[140ce9880]
 cursor_marker: Mem64[140ce9158]
+cursor_scale_factor: Mem32[140ec4dac]
 dat_requirement_error: Mem32[140d3e5b8]
 dcreep_list_begin: 140f21120
 dcreep_list_size: 140f21170

--- a/tests/compare/1232c-32.txt
+++ b/tests/compare/1232c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[10cf50c]
 current_campaign_mission: Mem32[10afa28]
 current_tooltip_ctrl: Mem32[e9b978]
 cursor_marker: Mem32[e9b4fc]
+cursor_scale_factor: Mem32[105d7a8]
 dat_requirement_error: Mem32[ed71a8]
 dcreep_list_begin: 10af978
 dcreep_list_size: 10af9a0

--- a/tests/compare/1232c-64.txt
+++ b/tests/compare/1232c-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f31338]
 current_campaign_mission: Mem64[140f0e348]
 current_tooltip_ctrl: Mem64[140cd6990]
 cursor_marker: Mem64[140cd6268]
+cursor_scale_factor: Mem32[140eb1eac]
 dat_requirement_error: Mem32[140d2b6b8]
 dcreep_list_begin: 140f0e230
 dcreep_list_size: 140f0e280

--- a/tests/compare/1232d-32.txt
+++ b/tests/compare/1232d-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[10d1c3c]
 current_campaign_mission: Mem32[10b2188]
 current_tooltip_ctrl: Mem32[e9e0d0]
 cursor_marker: Mem32[e9dc5c]
+cursor_scale_factor: Mem32[105ff00]
 dat_requirement_error: Mem32[ed9900]
 dcreep_list_begin: 10b20d8
 dcreep_list_size: 10b2100

--- a/tests/compare/1232d-64.txt
+++ b/tests/compare/1232d-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f64828]
 current_campaign_mission: Mem64[140f41888]
 current_tooltip_ctrl: Mem64[140d09ec0]
 cursor_marker: Mem64[140d09798]
+cursor_scale_factor: Mem32[140ee53ec]
 dat_requirement_error: Mem32[140d5ebf8]
 dcreep_list_begin: 140f41770
 dcreep_list_size: 140f417c0

--- a/tests/compare/1232e-32.txt
+++ b/tests/compare/1232e-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[10a7c34]
 current_campaign_mission: Mem32[1088180]
 current_tooltip_ctrl: Mem32[e740d0]
 cursor_marker: Mem32[e73c54]
+cursor_scale_factor: Mem32[1035f00]
 dat_requirement_error: Mem32[eaf900]
 dcreep_list_begin: 10880d0
 dcreep_list_size: 10880f8

--- a/tests/compare/1232e-64.txt
+++ b/tests/compare/1232e-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f49818]
 current_campaign_mission: Mem64[140f26868]
 current_tooltip_ctrl: Mem64[140ceeec0]
 cursor_marker: Mem64[140cee798]
+cursor_scale_factor: Mem32[140eca3dc]
 dat_requirement_error: Mem32[140d43be8]
 dcreep_list_begin: 140f26750
 dcreep_list_size: 140f267a0

--- a/tests/compare/1233a-32.txt
+++ b/tests/compare/1233a-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[1119844]
 current_campaign_mission: Mem32[10fb69c]
 current_tooltip_ctrl: Mem32[ee70d0]
 cursor_marker: Mem32[ee6c54]
+cursor_scale_factor: Mem32[10a8ed8]
 dat_requirement_error: Mem32[f228d8]
 dcreep_list_begin: 10fb5e8
 dcreep_list_size: 10fb610

--- a/tests/compare/1233a-64.txt
+++ b/tests/compare/1233a-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f6dfc8]
 current_campaign_mission: Mem64[140f4ca60]
 current_tooltip_ctrl: Mem64[140d14a40]
 cursor_marker: Mem64[140d14318]
+cursor_scale_factor: Mem32[140eeff1c]
 dat_requirement_error: Mem32[140d69728]
 dcreep_list_begin: 140f4c940
 dcreep_list_size: 140f4c990

--- a/tests/compare/1233b-32.txt
+++ b/tests/compare/1233b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[10f080c]
 current_campaign_mission: Mem32[10d2664]
 current_tooltip_ctrl: Mem32[ebe088]
 cursor_marker: Mem32[ebdc14]
+cursor_scale_factor: Mem32[107fe90]
 dat_requirement_error: Mem32[ef9890]
 dcreep_list_begin: 10d25b0
 dcreep_list_size: 10d25d8

--- a/tests/compare/1233b-64.txt
+++ b/tests/compare/1233b-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f62f58]
 current_campaign_mission: Mem64[140f419f0]
 current_tooltip_ctrl: Mem64[140d099c0]
 cursor_marker: Mem64[140d09298]
+cursor_scale_factor: Mem32[140ee4eac]
 dat_requirement_error: Mem32[140d5e6b8]
 dcreep_list_begin: 140f418d0
 dcreep_list_size: 140f41920

--- a/tests/compare/1233c-32.txt
+++ b/tests/compare/1233c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[10dd5f4]
 current_campaign_mission: Mem32[10bf48c]
 current_tooltip_ctrl: Mem32[eaae80]
 cursor_marker: Mem32[eaaa14]
+cursor_scale_factor: Mem32[106ccc8]
 dat_requirement_error: Mem32[ee66c8]
 dcreep_list_begin: 10bf3d8
 dcreep_list_size: 10bf400

--- a/tests/compare/1233c-64.txt
+++ b/tests/compare/1233c-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f86c68]
 current_campaign_mission: Mem64[140f65730]
 current_tooltip_ctrl: Mem64[140d2d6d0]
 cursor_marker: Mem64[140d2cfa8]
+cursor_scale_factor: Mem32[140f08bdc]
 dat_requirement_error: Mem32[140d823e8]
 dcreep_list_begin: 140f65610
 dcreep_list_size: 140f65660

--- a/tests/compare/1233d-32.txt
+++ b/tests/compare/1233d-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11035dc]
 current_campaign_mission: Mem32[10e5474]
 current_tooltip_ctrl: Mem32[ed0e78]
 cursor_marker: Mem32[ed0a0c]
+cursor_scale_factor: Mem32[1092cb8]
 dat_requirement_error: Mem32[f0c6b8]
 dcreep_list_begin: 10e53c0
 dcreep_list_size: 10e53e8

--- a/tests/compare/1233d-64.txt
+++ b/tests/compare/1233d-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f4bc78]
 current_campaign_mission: Mem64[140f2a740]
 current_tooltip_ctrl: Mem64[140cf26e8]
 cursor_marker: Mem64[140cf1fa8]
+cursor_scale_factor: Mem32[140ecdbec]
 dat_requirement_error: Mem32[140d473f8]
 dcreep_list_begin: 140f2a620
 dcreep_list_size: 140f2a670

--- a/tests/compare/1233e-32.txt
+++ b/tests/compare/1233e-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[10d5604]
 current_campaign_mission: Mem32[10b749c]
 current_tooltip_ctrl: Mem32[ea2e80]
 cursor_marker: Mem32[ea2a0c]
+cursor_scale_factor: Mem32[1064cc0]
 dat_requirement_error: Mem32[ede6c0]
 dcreep_list_begin: 10b73e8
 dcreep_list_size: 10b7410

--- a/tests/compare/1233e-64.txt
+++ b/tests/compare/1233e-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f67c88]
 current_campaign_mission: Mem64[140f46750]
 current_tooltip_ctrl: Mem64[140d0e6e0]
 cursor_marker: Mem64[140d0dfb8]
+cursor_scale_factor: Mem32[140ee9bec]
 dat_requirement_error: Mem32[140d633f8]
 dcreep_list_begin: 140f46630
 dcreep_list_size: 140f46680

--- a/tests/compare/1233f-32.txt
+++ b/tests/compare/1233f-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[10e9604]
 current_campaign_mission: Mem32[10cb49c]
 current_tooltip_ctrl: Mem32[eb6e88]
 cursor_marker: Mem32[eb6a14]
+cursor_scale_factor: Mem32[1078cc8]
 dat_requirement_error: Mem32[ef26c8]
 dcreep_list_begin: 10cb3e8
 dcreep_list_size: 10cb410

--- a/tests/compare/1233f-64.txt
+++ b/tests/compare/1233f-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f53c78]
 current_campaign_mission: Mem64[140f32740]
 current_tooltip_ctrl: Mem64[140cfa6c8]
 cursor_marker: Mem64[140cf9f98]
+cursor_scale_factor: Mem32[140ed5bdc]
 dat_requirement_error: Mem32[140d4f3e8]
 dcreep_list_begin: 140f32620
 dcreep_list_size: 140f32670

--- a/tests/compare/1233g-32.txt
+++ b/tests/compare/1233g-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[110577c]
 current_campaign_mission: Mem32[10e9668]
 current_tooltip_ctrl: Mem32[ed4e08]
 cursor_marker: Mem32[ed4994]
+cursor_scale_factor: Mem32[1096d00]
 dat_requirement_error: Mem32[f10648]
 dcreep_list_begin: 10e9590
 dcreep_list_size: 10e95b8

--- a/tests/compare/1233g-64.txt
+++ b/tests/compare/1233g-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f8bb88]
 current_campaign_mission: Mem64[140f6cde8]
 current_tooltip_ctrl: Mem64[140d348d8]
 cursor_marker: Mem64[140d341a8]
+cursor_scale_factor: Mem32[140f0ffcc]
 dat_requirement_error: Mem32[140d89608]
 dcreep_list_begin: 140f6cc80
 dcreep_list_size: 140f6ccd0

--- a/tests/compare/1233h-32.txt
+++ b/tests/compare/1233h-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[10ff78c]
 current_campaign_mission: Mem32[10e3678]
 current_tooltip_ctrl: Mem32[ecee10]
 cursor_marker: Mem32[ece994]
+cursor_scale_factor: Mem32[1090d08]
 dat_requirement_error: Mem32[f0a650]
 dcreep_list_begin: 10e35a0
 dcreep_list_size: 10e35c8

--- a/tests/compare/1233h-64.txt
+++ b/tests/compare/1233h-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f6ab98]
 current_campaign_mission: Mem64[140f4bdf8]
 current_tooltip_ctrl: Mem64[140d138e0]
 cursor_marker: Mem64[140d131a8]
+cursor_scale_factor: Mem32[140eeefcc]
 dat_requirement_error: Mem32[140d68608]
 dcreep_list_begin: 140f4bc90
 dcreep_list_size: 140f4bce0

--- a/tests/compare/1233i-32.txt
+++ b/tests/compare/1233i-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[1119bec]
 current_campaign_mission: Mem32[10fdad8]
 current_tooltip_ctrl: Mem32[ee9270]
 cursor_marker: Mem32[ee8e04]
+cursor_scale_factor: Mem32[10ab168]
 dat_requirement_error: Mem32[f24ab0]
 dcreep_list_begin: 10fda00
 dcreep_list_size: 10fda28

--- a/tests/compare/1234_ptr1-32.txt
+++ b/tests/compare/1234_ptr1-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11b780c]
 current_campaign_mission: Mem32[119b6f0]
 current_tooltip_ctrl: Mem32[f86e90]
 cursor_marker: Mem32[f86a1c]
+cursor_scale_factor: Mem32[1148d80]
 dat_requirement_error: Mem32[fc26c8]
 dcreep_list_begin: 119b618
 dcreep_list_size: 119b640

--- a/tests/compare/1234_ptr1-64.txt
+++ b/tests/compare/1234_ptr1-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[14108be88]
 current_campaign_mission: Mem64[14106d0d8]
 current_tooltip_ctrl: Mem64[140e34be8]
 cursor_marker: Mem64[140e344b8]
+cursor_scale_factor: Mem32[1410102bc]
 dat_requirement_error: Mem32[140e898f8]
 dcreep_list_begin: 14106cf70
 dcreep_list_size: 14106cfc0

--- a/tests/compare/1234a-32.txt
+++ b/tests/compare/1234a-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[113e754]
 current_campaign_mission: Mem32[1122638]
 current_tooltip_ctrl: Mem32[f0ddd0]
 cursor_marker: Mem32[f0d95c]
+cursor_scale_factor: Mem32[10cfcc8]
 dat_requirement_error: Mem32[f49610]
 dcreep_list_begin: 1122560
 dcreep_list_size: 1122588

--- a/tests/compare/1234a-64.txt
+++ b/tests/compare/1234a-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140faae08]
 current_campaign_mission: Mem64[140f8c068]
 current_tooltip_ctrl: Mem64[140d53b60]
 cursor_marker: Mem64[140d53428]
+cursor_scale_factor: Mem32[140f2f24c]
 dat_requirement_error: Mem32[140da8888]
 dcreep_list_begin: 140f8bf00
 dcreep_list_size: 140f8bf50

--- a/tests/compare/1234b-32.txt
+++ b/tests/compare/1234b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[1107984]
 current_campaign_mission: Mem32[10eb868]
 current_tooltip_ctrl: Mem32[ed6ff8]
 cursor_marker: Mem32[ed6b8c]
+cursor_scale_factor: Mem32[1098ef0]
 dat_requirement_error: Mem32[f12838]
 dcreep_list_begin: 10eb790
 dcreep_list_size: 10eb7b8

--- a/tests/compare/1234b-64.txt
+++ b/tests/compare/1234b-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f88088]
 current_campaign_mission: Mem64[140f692e8]
 current_tooltip_ctrl: Mem64[140d30de0]
 cursor_marker: Mem64[140d306b8]
+cursor_scale_factor: Mem32[140f0c4cc]
 dat_requirement_error: Mem32[140d85b08]
 dcreep_list_begin: 140f69180
 dcreep_list_size: 140f691d0

--- a/tests/compare/1234c-32.txt
+++ b/tests/compare/1234c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[111f984]
 current_campaign_mission: Mem32[1103868]
 current_tooltip_ctrl: Mem32[eef000]
 cursor_marker: Mem32[eeeb8c]
+cursor_scale_factor: Mem32[10b0ef8]
 dat_requirement_error: Mem32[f2a840]
 dcreep_list_begin: 1103790
 dcreep_list_size: 11037b8

--- a/tests/compare/1234c-64.txt
+++ b/tests/compare/1234c-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140f920a8]
 current_campaign_mission: Mem64[140f73308]
 current_tooltip_ctrl: Mem64[140d3adf8]
 cursor_marker: Mem64[140d3a6b8]
+cursor_scale_factor: Mem32[140f164ec]
 dat_requirement_error: Mem32[140d8fb28]
 dcreep_list_begin: 140f731a0
 dcreep_list_size: 140f731f0

--- a/tests/compare/1234d-32.txt
+++ b/tests/compare/1234d-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[10ea99c]
 current_campaign_mission: Mem32[10ce880]
 current_tooltip_ctrl: Mem32[eba010]
 cursor_marker: Mem32[eb9b9c]
+cursor_scale_factor: Mem32[107bf08]
 dat_requirement_error: Mem32[ef5850]
 dcreep_list_begin: 10ce7a8
 dcreep_list_size: 10ce7d0

--- a/tests/compare/1234d-64.txt
+++ b/tests/compare/1234d-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[140fc0088]
 current_campaign_mission: Mem64[140fa12e8]
 current_tooltip_ctrl: Mem64[140d68df0]
 cursor_marker: Mem64[140d686c8]
+cursor_scale_factor: Mem32[140f444cc]
 dat_requirement_error: Mem32[140dbdb08]
 dcreep_list_begin: 140fa1180
 dcreep_list_size: 140fa11d0

--- a/tests/compare/1235a-32.txt
+++ b/tests/compare/1235a-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11acd54]
 current_campaign_mission: Mem32[1190c38]
 current_tooltip_ctrl: Mem32[f7c3d8]
 cursor_marker: Mem32[f7bf64]
+cursor_scale_factor: Mem32[113e2d0]
 dat_requirement_error: Mem32[fb7c18]
 dcreep_list_begin: 1190b60
 dcreep_list_size: 1190b88

--- a/tests/compare/1235a-64.txt
+++ b/tests/compare/1235a-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[141067658]
 current_campaign_mission: Mem64[1410488a8]
 current_tooltip_ctrl: Mem64[140e10398]
 cursor_marker: Mem64[140e0fc58]
+cursor_scale_factor: Mem32[140feba8c]
 dat_requirement_error: Mem32[140e650c8]
 dcreep_list_begin: 141048740
 dcreep_list_size: 141048790

--- a/tests/compare/1235b-32.txt
+++ b/tests/compare/1235b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11cec8c]
 current_campaign_mission: Mem32[11b2b70]
 current_tooltip_ctrl: Mem32[f9e310]
 cursor_marker: Mem32[f9dea4]
+cursor_scale_factor: Mem32[1160208]
 dat_requirement_error: Mem32[fd9b50]
 dcreep_list_begin: 11b2a98
 dcreep_list_size: 11b2ac0

--- a/tests/compare/1235b-64.txt
+++ b/tests/compare/1235b-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[141064548]
 current_campaign_mission: Mem64[141045798]
 current_tooltip_ctrl: Mem64[140e0d2a0]
 cursor_marker: Mem64[140e0cb68]
+cursor_scale_factor: Mem32[140fe897c]
 dat_requirement_error: Mem32[140e61fb8]
 dcreep_list_begin: 141045630
 dcreep_list_size: 141045680

--- a/tests/compare/1235c-32.txt
+++ b/tests/compare/1235c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11c1cac]
 current_campaign_mission: Mem32[11a5b90]
 current_tooltip_ctrl: Mem32[f91320]
 cursor_marker: Mem32[f90ea4]
+cursor_scale_factor: Mem32[1153218]
 dat_requirement_error: Mem32[fccb60]
 dcreep_list_begin: 11a5ab8
 dcreep_list_size: 11a5ae0

--- a/tests/compare/1235c-64.txt
+++ b/tests/compare/1235c-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[14107b548]
 current_campaign_mission: Mem64[14105c798]
 current_tooltip_ctrl: Mem64[140e24290]
 cursor_marker: Mem64[140e23b68]
+cursor_scale_factor: Mem32[140fff97c]
 dat_requirement_error: Mem32[140e78fb8]
 dcreep_list_begin: 14105c630
 dcreep_list_size: 14105c680

--- a/tests/compare/1235d-32.txt
+++ b/tests/compare/1235d-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11eec2c]
 current_campaign_mission: Mem32[11d2b10]
 current_tooltip_ctrl: Mem32[fbe2a0]
 cursor_marker: Mem32[fbde2c]
+cursor_scale_factor: Mem32[11801a0]
 dat_requirement_error: Mem32[ff9ae8]
 dcreep_list_begin: 11d2a38
 dcreep_list_size: 11d2a60

--- a/tests/compare/1235d-64.txt
+++ b/tests/compare/1235d-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[1410684a8]
 current_campaign_mission: Mem64[141049708]
 current_tooltip_ctrl: Mem64[140e11208]
 cursor_marker: Mem64[140e10ad8]
+cursor_scale_factor: Mem32[140fec8dc]
 dat_requirement_error: Mem32[140e65f18]
 dcreep_list_begin: 1410495a0
 dcreep_list_size: 1410495f0

--- a/tests/compare/1235e-32.txt
+++ b/tests/compare/1235e-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11dac1c]
 current_campaign_mission: Mem32[11beb08]
 current_tooltip_ctrl: Mem32[faa298]
 cursor_marker: Mem32[fa9e24]
+cursor_scale_factor: Mem32[116c198]
 dat_requirement_error: Mem32[fe5ae0]
 dcreep_list_begin: 11bea30
 dcreep_list_size: 11bea58

--- a/tests/compare/1235e-64.txt
+++ b/tests/compare/1235e-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[141083528]
 current_campaign_mission: Mem64[141064788]
 current_tooltip_ctrl: Mem64[140e2c290]
 cursor_marker: Mem64[140e2bb68]
+cursor_scale_factor: Mem32[14100795c]
 dat_requirement_error: Mem32[140e80fa8]
 dcreep_list_begin: 141064620
 dcreep_list_size: 141064670

--- a/tests/compare/1235f-32.txt
+++ b/tests/compare/1235f-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11a4c14]
 current_campaign_mission: Mem32[1188b00]
 current_tooltip_ctrl: Mem32[f74290]
 cursor_marker: Mem32[f73e24]
+cursor_scale_factor: Mem32[1136190]
 dat_requirement_error: Mem32[fafad8]
 dcreep_list_begin: 1188a28
 dcreep_list_size: 1188a50

--- a/tests/compare/1235f-64.txt
+++ b/tests/compare/1235f-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[141071558]
 current_campaign_mission: Mem64[1410527b8]
 current_tooltip_ctrl: Mem64[140e1a2a8]
 cursor_marker: Mem64[140e19b78]
+cursor_scale_factor: Mem32[140ff598c]
 dat_requirement_error: Mem32[140e6efc8]
 dcreep_list_begin: 141052650
 dcreep_list_size: 1410526a0

--- a/tests/compare/1235g-32.txt
+++ b/tests/compare/1235g-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11efc1c]
 current_campaign_mission: Mem32[11d3b08]
 current_tooltip_ctrl: Mem32[fbf290]
 cursor_marker: Mem32[fbee24]
+cursor_scale_factor: Mem32[1181190]
 dat_requirement_error: Mem32[ffaad8]
 dcreep_list_begin: 11d3a30
 dcreep_list_size: 11d3a58

--- a/tests/compare/1235g-64.txt
+++ b/tests/compare/1235g-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[1410a3538]
 current_campaign_mission: Mem64[141084798]
 current_tooltip_ctrl: Mem64[140e4c2b0]
 cursor_marker: Mem64[140e4bb88]
+cursor_scale_factor: Mem32[14102796c]
 dat_requirement_error: Mem32[140ea0fb8]
 dcreep_list_begin: 141084630
 dcreep_list_size: 141084680

--- a/tests/compare/1235h-32.txt
+++ b/tests/compare/1235h-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[12002ec]
 current_campaign_mission: Mem32[11e94a0]
 current_tooltip_ctrl: Mem32[fd4510]
 cursor_marker: Mem32[fd40ac]
+cursor_scale_factor: Mem32[1196bd0]
 dat_requirement_error: Mem32[1010550]
 dcreep_list_begin: 11e93c8
 dcreep_list_size: 11e93f0

--- a/tests/compare/1235h-64.txt
+++ b/tests/compare/1235h-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[1410af068]
 current_campaign_mission: Mem64[141097658]
 current_tooltip_ctrl: Mem64[140e5ea60]
 cursor_marker: Mem64[140e5e348]
+cursor_scale_factor: Mem32[14103a8ec]
 dat_requirement_error: Mem32[140eb3f88]
 dcreep_list_begin: 1410974f0
 dcreep_list_size: 141097540

--- a/tests/compare/1236a-32.txt
+++ b/tests/compare/1236a-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11e72f4]
 current_campaign_mission: Mem32[11d04a8]
 current_tooltip_ctrl: Mem32[fbb518]
 cursor_marker: Mem32[fbb0ac]
+cursor_scale_factor: Mem32[117dbd8]
 dat_requirement_error: Mem32[ff7558]
 dcreep_list_begin: 11d03d0
 dcreep_list_size: 11d03f8

--- a/tests/compare/1236a-64.txt
+++ b/tests/compare/1236a-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[14109c078]
 current_campaign_mission: Mem64[141084668]
 current_tooltip_ctrl: Mem64[140e4ba70]
 cursor_marker: Mem64[140e4b358]
+cursor_scale_factor: Mem32[1410278fc]
 dat_requirement_error: Mem32[140ea0f98]
 dcreep_list_begin: 141084500
 dcreep_list_size: 141084550

--- a/tests/compare/1236b-32.txt
+++ b/tests/compare/1236b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[121b2f4]
 current_campaign_mission: Mem32[12044a8]
 current_tooltip_ctrl: Mem32[fef510]
 cursor_marker: Mem32[fef0ac]
+cursor_scale_factor: Mem32[11b1bd0]
 dat_requirement_error: Mem32[102b550]
 dcreep_list_begin: 12043d0
 dcreep_list_size: 12043f8

--- a/tests/compare/1236b-64.txt
+++ b/tests/compare/1236b-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[1410d4078]
 current_campaign_mission: Mem64[1410bc668]
 current_tooltip_ctrl: Mem64[140e83a80]
 cursor_marker: Mem64[140e83358]
+cursor_scale_factor: Mem32[14105f8fc]
 dat_requirement_error: Mem32[140ed8f98]
 dcreep_list_begin: 1410bc500
 dcreep_list_size: 1410bc550

--- a/tests/compare/1237a-32.txt
+++ b/tests/compare/1237a-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11fc2f4]
 current_campaign_mission: Mem32[11e54a8]
 current_tooltip_ctrl: Mem32[fd0518]
 cursor_marker: Mem32[fd00ac]
+cursor_scale_factor: Mem32[1192bd8]
 dat_requirement_error: Mem32[100c558]
 dcreep_list_begin: 11e53d0
 dcreep_list_size: 11e53f8

--- a/tests/compare/1237a-64.txt
+++ b/tests/compare/1237a-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[1410e6078]
 current_campaign_mission: Mem64[1410ce668]
 current_tooltip_ctrl: Mem64[140e95a78]
 cursor_marker: Mem64[140e95358]
+cursor_scale_factor: Mem32[1410718fc]
 dat_requirement_error: Mem32[140eeaf98]
 dcreep_list_begin: 1410ce500
 dcreep_list_size: 1410ce550

--- a/tests/compare/1238a-32.txt
+++ b/tests/compare/1238a-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[12242f4]
 current_campaign_mission: Mem32[120d4a8]
 current_tooltip_ctrl: Mem32[ff8510]
 cursor_marker: Mem32[ff80ac]
+cursor_scale_factor: Mem32[11babd0]
 dat_requirement_error: Mem32[1034550]
 dcreep_list_begin: 120d3d0
 dcreep_list_size: 120d3f8

--- a/tests/compare/1238a-64.txt
+++ b/tests/compare/1238a-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[1410f1088]
 current_campaign_mission: Mem64[1410d9678]
 current_tooltip_ctrl: Mem64[140ea0a80]
 cursor_marker: Mem64[140ea0358]
+cursor_scale_factor: Mem32[14107c90c]
 dat_requirement_error: Mem32[140ef5fa8]
 dcreep_list_begin: 1410d9510
 dcreep_list_size: 1410d9560

--- a/tests/compare/1238b-32.txt
+++ b/tests/compare/1238b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[12292f4]
 current_campaign_mission: Mem32[12124a8]
 current_tooltip_ctrl: Mem32[ffd510]
 cursor_marker: Mem32[ffd0ac]
+cursor_scale_factor: Mem32[11bfbd0]
 dat_requirement_error: Mem32[1039550]
 dcreep_list_begin: 12123d0
 dcreep_list_size: 12123f8

--- a/tests/compare/1238b-64.txt
+++ b/tests/compare/1238b-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[1410e3058]
 current_campaign_mission: Mem64[1410cb648]
 current_tooltip_ctrl: Mem64[140e92a60]
 cursor_marker: Mem64[140e92348]
+cursor_scale_factor: Mem32[14106e8dc]
 dat_requirement_error: Mem32[140ee7f78]
 dcreep_list_begin: 1410cb4e0
 dcreep_list_size: 1410cb530

--- a/tests/compare/1238c-32.txt
+++ b/tests/compare/1238c-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[12032fc]
 current_campaign_mission: Mem32[11ec4b0]
 current_tooltip_ctrl: Mem32[fd7518]
 cursor_marker: Mem32[fd70ac]
+cursor_scale_factor: Mem32[1199bd8]
 dat_requirement_error: Mem32[1013558]
 dcreep_list_begin: 11ec3d8
 dcreep_list_size: 11ec400

--- a/tests/compare/1238c-64.txt
+++ b/tests/compare/1238c-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[1410b9068]
 current_campaign_mission: Mem64[1410a1658]
 current_tooltip_ctrl: Mem64[140e68a68]
 cursor_marker: Mem64[140e68348]
+cursor_scale_factor: Mem32[1410448ec]
 dat_requirement_error: Mem32[140ebdf88]
 dcreep_list_begin: 1410a14f0
 dcreep_list_size: 1410a1540

--- a/tests/compare/1238d-32.txt
+++ b/tests/compare/1238d-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11dadb8]
 current_campaign_mission: Mem32[1011568]
 current_tooltip_ctrl: Mem32[1011114]
 cursor_marker: Mem32[11c382c]
+cursor_scale_factor: Mem32[103329c]
 dat_requirement_error: Mem32[101f570]
 dcreep_list_begin: 1026b28
 dcreep_list_size: 1026b50

--- a/tests/compare/1238d-64.txt
+++ b/tests/compare/1238d-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[141092ab0]
 current_campaign_mission: Mem64[140eaf7d0]
 current_tooltip_ctrl: Mem64[140eaf208]
 cursor_marker: Mem64[141072268]
+cursor_scale_factor: Mem32[140ed8e98]
 dat_requirement_error: Mem32[140ebe8e0]
 dcreep_list_begin: 140ecc0d0
 dcreep_list_size: 140ecc120

--- a/tests/compare/1238e-32.txt
+++ b/tests/compare/1238e-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11cbe10]
 current_campaign_mission: Mem32[10025b8]
 current_tooltip_ctrl: Mem32[1002164]
 cursor_marker: Mem32[11b4884]
+cursor_scale_factor: Mem32[10242ec]
 dat_requirement_error: Mem32[10105c0]
 dcreep_list_begin: 1017b78
 dcreep_list_size: 1017ba0

--- a/tests/compare/1238f-32.txt
+++ b/tests/compare/1238f-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11e72f4]
 current_campaign_mission: Mem32[11d04a8]
 current_tooltip_ctrl: Mem32[fbb518]
 cursor_marker: Mem32[fbb0ac]
+cursor_scale_factor: Mem32[117dbd8]
 dat_requirement_error: Mem32[ff7558]
 dcreep_list_begin: 11d03d0
 dcreep_list_size: 11d03f8

--- a/tests/compare/1238f-64.txt
+++ b/tests/compare/1238f-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[1410a6068]
 current_campaign_mission: Mem64[14108e658]
 current_tooltip_ctrl: Mem64[140e55a60]
 cursor_marker: Mem64[140e55348]
+cursor_scale_factor: Mem32[1410318ec]
 dat_requirement_error: Mem32[140eaaf88]
 dcreep_list_begin: 14108e4f0
 dcreep_list_size: 14108e540

--- a/tests/compare/1239a-32.txt
+++ b/tests/compare/1239a-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[12092f4]
 current_campaign_mission: Mem32[11f24a8]
 current_tooltip_ctrl: Mem32[fdd518]
 cursor_marker: Mem32[fdd0ac]
+cursor_scale_factor: Mem32[119fbd8]
 dat_requirement_error: Mem32[1019558]
 dcreep_list_begin: 11f23d0
 dcreep_list_size: 11f23f8

--- a/tests/compare/1239a-64.txt
+++ b/tests/compare/1239a-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[141099068]
 current_campaign_mission: Mem64[141081658]
 current_tooltip_ctrl: Mem64[140e48a60]
 cursor_marker: Mem64[140e48348]
+cursor_scale_factor: Mem32[1410248ec]
 dat_requirement_error: Mem32[140e9df88]
 dcreep_list_begin: 1410814f0
 dcreep_list_size: 141081540

--- a/tests/compare/1239b-32.txt
+++ b/tests/compare/1239b-32.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem32[11e72f4]
 current_campaign_mission: Mem32[11d04a8]
 current_tooltip_ctrl: Mem32[fbb510]
 cursor_marker: Mem32[fbb0ac]
+cursor_scale_factor: Mem32[117dbd0]
 dat_requirement_error: Mem32[ff7550]
 dcreep_list_begin: 11d03d0
 dcreep_list_size: 11d03f8

--- a/tests/compare/1239b-64.txt
+++ b/tests/compare/1239b-64.txt
@@ -347,6 +347,7 @@ creep_tile_borders: Mem64[14109e088]
 current_campaign_mission: Mem64[141086678]
 current_tooltip_ctrl: Mem64[140e4da88]
 cursor_marker: Mem64[140e4d358]
+cursor_scale_factor: Mem32[14102990c]
 dat_requirement_error: Mem32[140ea2fa8]
 dcreep_list_begin: 141086510
 dcreep_list_size: 141086560

--- a/tests/everything.rs
+++ b/tests/everything.rs
@@ -1646,7 +1646,7 @@ fn test_nongeneric<'e, E: ExecutionState<'e>>(
                 RgbColors | DisableColorChoice | UseMapSetRgbColor | SfxData | SoundChannels |
                 Images | TilesetCv5 | TilesetData | TilesetVx4Ex | TileDefaultFlags |
                 MinitileGraphics | MinitileData | FoliageState | CreepOriginalTiles |
-                CreepTileBorders =>
+                CreepTileBorders | CursorScaleFactor =>
             {
                 continue;
             }
@@ -2403,6 +2403,15 @@ fn test_nongeneric<'e, E: ExecutionState<'e>>(
         assert!(map_names.is_none());
     } else {
         check_global_struct_opt(map_names, binary, "campaign_map_names")
+    }
+
+    // Cursor scaling was added in 1.21.4
+    let cursor_scale_factor = analysis.cursor_scale_factor();
+    if minor_version < 21 || (minor_version == 21 && patch_version < 4) {
+        assert!(cursor_scale_factor.is_none());
+    } else {
+        assert!(cursor_scale_factor.is_some());
+        check_global(cursor_scale_factor.unwrap(), binary, "cursor_scale_factor");
     }
 
     // init_game_map is very inconsistently inlined on 32bit


### PR DESCRIPTION
This seems to have been added in 1.21.4, binaries before that point don't do any of this sort of math that I can see.

I'm missing a few of the more recent binaries for test dumps, so those will have to be added. I'm also not entirely sure I didn't overcomplicate the finding of this thing, but hopefully this is somewhat reasonable :)