### PR TITLE
Add analysis for the save_replay function.

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -216,6 +216,7 @@ results! {
         PlaySound => play_sound,
         AiPrepareMovingTo => ai_prepare_moving_to,
         StepReplayCommands => step_replay_commands,
+        SaveReplay => save_replay,
         AiTrainMilitary => ai_train_military,
         AiAddMilitaryToRegion => ai_add_military_to_region,
         GetRegion => get_region => cache_regions,
@@ -1290,6 +1291,10 @@ impl<'e, E: ExecutionState<'e>> Analysis<'e, E> {
         self.enter(AnalysisCache::is_replay)
     }
 
+    pub fn save_replay(&mut self) -> Option<E::VirtualAddress> {
+        self.enter(AnalysisCache::save_replay)
+    }
+
     pub fn send_command(&mut self) -> Option<E::VirtualAddress> {
         self.enter(AnalysisCache::send_command)
     }
@@ -2231,6 +2236,13 @@ impl<'e, E: ExecutionState<'e>> AnalysisCache<'e, E> {
         self.cache_single_operand(OperandAnalysis::IsReplay, |s| {
             let switch = s.process_commands_switch(actx)?;
             commands::is_replay(actx, &switch)
+        })
+    }
+
+    fn save_replay(&mut self, actx: &AnalysisCtx<'e, E>) -> Option<E::VirtualAddress> {
+        self.cache_single_address(AddressAnalysis::SaveReplay, |s| {
+            let funcs = s.function_finder();
+            commands::save_replay(actx, &funcs)
         })
     }
 

--- a/tests/compare/12010-32.txt
+++ b/tests/compare/12010-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a9390
 run_dialog: 008f7c50
 run_menus: 00693ab0
 run_modern_dialog: 008a6380
+save_replay: None
 sc_main: 006a5ee0
 select_map_entry: 0089c650
 select_mouse_move: 00736a00

--- a/tests/compare/12011-32.txt
+++ b/tests/compare/12011-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0058d890
 run_dialog: 008d1940
 run_menus: 00676a30
 run_modern_dialog: 0087fe40
+save_replay: 006dadd0
 sc_main: 006884d0
 select_map_entry: 008761c0
 select_mouse_move: 00719370

--- a/tests/compare/12011b-32.txt
+++ b/tests/compare/12011b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00699700
 run_dialog: 009db480
 run_menus: 0078d920
 run_modern_dialog: 00989710
+save_replay: 007f3050
 sc_main: 0079e840
 select_map_entry: 00980150
 select_mouse_move: 008368b0

--- a/tests/compare/1207-32.txt
+++ b/tests/compare/1207-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 006855b0
 run_dialog: 009f9b10
 run_menus: 00782b10
 run_modern_dialog: 009a68d0
+save_replay: None
 sc_main: 00794280
 select_map_entry: 0099c750
 select_mouse_move: 008395f0

--- a/tests/compare/1208-32.txt
+++ b/tests/compare/1208-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00685570
 run_dialog: 009e0230
 run_menus: 007793c0
 run_modern_dialog: 0098be80
+save_replay: None
 sc_main: 0078a990
 select_map_entry: 00981f60
 select_mouse_move: 00828fc0

--- a/tests/compare/1209-32.txt
+++ b/tests/compare/1209-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0059ad70
 run_dialog: 008f60e0
 run_menus: 00675330
 run_modern_dialog: 008a2ae0
+save_replay: None
 sc_main: 00686e80
 select_map_entry: 00898030
 select_mouse_move: 00717630

--- a/tests/compare/1209b-32.txt
+++ b/tests/compare/1209b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0058c500
 run_dialog: 008fcd60
 run_menus: 00699370
 run_modern_dialog: 008abe60
+save_replay: None
 sc_main: 006aa780
 select_map_entry: 008a1ed0
 select_mouse_move: 0073ec00

--- a/tests/compare/1210-32.txt
+++ b/tests/compare/1210-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00594e60
 run_dialog: 00905ab0
 run_menus: 006a9020
 run_modern_dialog: 008ae8e0
+save_replay: 0070b2a0
 sc_main: 006ba630
 select_map_entry: 008a4a60
 select_mouse_move: 0074d1f0

--- a/tests/compare/1210b-32.txt
+++ b/tests/compare/1210b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a03b0
 run_dialog: 008e51d0
 run_menus: 006a3f20
 run_modern_dialog: 00894830
+save_replay: 00706850
 sc_main: 006b4f40
 select_map_entry: 0088b6b0
 select_mouse_move: 0074af90

--- a/tests/compare/1211-32.txt
+++ b/tests/compare/1211-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 006a1360
 run_dialog: 00a38620
 run_menus: 007c2230
 run_modern_dialog: 009e5400
+save_replay: 00823280
 sc_main: 007d41e0
 select_map_entry: 009db390
 select_mouse_move: 00869a50

--- a/tests/compare/1211b-32.txt
+++ b/tests/compare/1211b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a1950
 run_dialog: 00967230
 run_menus: 006eb750
 run_modern_dialog: 00915590
+save_replay: 0074e010
 sc_main: 006fd3c0
 select_map_entry: 0090b5c0
 select_mouse_move: 007941b0

--- a/tests/compare/1212-32.txt
+++ b/tests/compare/1212-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00573e40
 run_dialog: 008f3df0
 run_menus: 00689a10
 run_modern_dialog: 008a2f90
+save_replay: 006ebfd0
 sc_main: 0069a100
 select_map_entry: 00897bb0
 select_mouse_move: 00733d50

--- a/tests/compare/1212b-32.txt
+++ b/tests/compare/1212b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005667c0
 run_dialog: 00899d60
 run_menus: 0065b200
 run_modern_dialog: 00849090
+save_replay: 006bbf30
 sc_main: 0066a950
 select_map_entry: 0083d3f0
 select_mouse_move: 006ff0b0

--- a/tests/compare/1213-32.txt
+++ b/tests/compare/1213-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00566940
 run_dialog: 00885ab0
 run_menus: 0065f390
 run_modern_dialog: 00832160
+save_replay: 006b4770
 sc_main: 0066dfc0
 select_map_entry: 00827e10
 select_mouse_move: 006f10f0

--- a/tests/compare/1213b-32.txt
+++ b/tests/compare/1213b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00561f50
 run_dialog: 00886da0
 run_menus: 0065ec90
 run_modern_dialog: 00834ad0
+save_replay: 006b6780
 sc_main: 0066dfa0
 select_map_entry: 0082a340
 select_mouse_move: 006f35d0

--- a/tests/compare/1214-32.txt
+++ b/tests/compare/1214-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00565130
 run_dialog: 0088e920
 run_menus: 00677fd0
 run_modern_dialog: 0083c810
+save_replay: 006cf500
 sc_main: 00686e00
 select_map_entry: 00832720
 select_mouse_move: 0070bc00

--- a/tests/compare/1214b-32.txt
+++ b/tests/compare/1214b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00558cc0
 run_dialog: 0086cf50
 run_menus: 00665290
 run_modern_dialog: 008196c0
+save_replay: 006b9050
 sc_main: 00674500
 select_map_entry: 0080f960
 select_mouse_move: 006f5320

--- a/tests/compare/1214c-32.txt
+++ b/tests/compare/1214c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0055ebb0
 run_dialog: 0086b270
 run_menus: 0065f840
 run_modern_dialog: 00819d60
+save_replay: 006b52b0
 sc_main: 0066ea20
 select_map_entry: 008101a0
 select_mouse_move: 006efc40

--- a/tests/compare/1215-32.txt
+++ b/tests/compare/1215-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00565ca0
 run_dialog: 0088b180
 run_menus: 00661f50
 run_modern_dialog: 00838be0
+save_replay: 006b9320
 sc_main: 00671840
 select_map_entry: 0082e7a0
 select_mouse_move: 006f5150

--- a/tests/compare/1215b-32.txt
+++ b/tests/compare/1215b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00572920
 run_dialog: 008af5e0
 run_menus: 00671630
 run_modern_dialog: 0085cf00
+save_replay: 006d1ce0
 sc_main: 00681a30
 select_map_entry: 008527a0
 select_mouse_move: 00711540

--- a/tests/compare/1215c-32.txt
+++ b/tests/compare/1215c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0056e6e0
 run_dialog: 008b5570
 run_menus: 00696090
 run_modern_dialog: 00863200
+save_replay: 006f53d0
 sc_main: 006a5bf0
 select_map_entry: 00859030
 select_mouse_move: 00730e70

--- a/tests/compare/1215d-32.txt
+++ b/tests/compare/1215d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0056fa40
 run_dialog: 00893950
 run_menus: 00679330
 run_modern_dialog: 0083f7e0
+save_replay: 006cf4b0
 sc_main: 006890e0
 select_map_entry: 00835740
 select_mouse_move: 0070c260

--- a/tests/compare/1215e-32.txt
+++ b/tests/compare/1215e-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00562160
 run_dialog: 0087ff10
 run_menus: 006540b0
 run_modern_dialog: 0082c300
+save_replay: 006b71b0
 sc_main: 00664020
 select_map_entry: 00821ed0
 select_mouse_move: 006f3980

--- a/tests/compare/1215f-32.txt
+++ b/tests/compare/1215f-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00562160
 run_dialog: 0087ff10
 run_menus: 006540b0
 run_modern_dialog: 0082c300
+save_replay: 006b71b0
 sc_main: 00664020
 select_map_entry: 00821ed0
 select_mouse_move: 006f3980

--- a/tests/compare/1215g-32.txt
+++ b/tests/compare/1215g-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0055f950
 run_dialog: 00882a20
 run_menus: 00663750
 run_modern_dialog: 0082ff70
+save_replay: 006bcde0
 sc_main: 00673b60
 select_map_entry: 005ab290
 select_mouse_move: 006f9040

--- a/tests/compare/1215h-32.txt
+++ b/tests/compare/1215h-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00570c80
 run_dialog: 008acfa0
 run_menus: 00687660
 run_modern_dialog: 00859e80
+save_replay: 006e24f0
 sc_main: 00698040
 select_map_entry: 005b7130
 select_mouse_move: 0071c580

--- a/tests/compare/1215i-32.txt
+++ b/tests/compare/1215i-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00574cf0
 run_dialog: 008aabe0
 run_menus: 0066f3b0
 run_modern_dialog: 00853c30
+save_replay: 006ca7a0
 sc_main: 00680930
 select_map_entry: 005be160
 select_mouse_move: 00708c60

--- a/tests/compare/1220-32.txt
+++ b/tests/compare/1220-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00560560
 run_dialog: 008a16b0
 run_menus: 00662c60
 run_modern_dialog: 0084c230
+save_replay: 006cba40
 sc_main: 00674040
 select_map_entry: 005ab820
 select_mouse_move: 0070b970

--- a/tests/compare/1220b-32.txt
+++ b/tests/compare/1220b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00571e00
 run_dialog: 008aa2a0
 run_menus: 00671810
 run_modern_dialog: 00853ec0
+save_replay: 006c9470
 sc_main: 00682ae0
 select_map_entry: 005b2260
 select_mouse_move: 00708240

--- a/tests/compare/1220c-32.txt
+++ b/tests/compare/1220c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005696f0
 run_dialog: 008a5be0
 run_menus: 0067f900
 run_modern_dialog: 0084f7f0
+save_replay: 006d9790
 sc_main: 00690bf0
 select_map_entry: 005b5920
 select_mouse_move: 0071c7c0

--- a/tests/compare/1220d-32.txt
+++ b/tests/compare/1220d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00566d10
 run_dialog: 008ab9b0
 run_menus: 0066f3b0
 run_modern_dialog: 00854370
+save_replay: 006cf4c0
 sc_main: 00680cf0
 select_map_entry: 005bbd40
 select_mouse_move: 0070d650

--- a/tests/compare/1220e-32.txt
+++ b/tests/compare/1220e-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00571560
 run_dialog: 008c8740
 run_menus: 00669300
 run_modern_dialog: 008729c0
+save_replay: 006d2db0
 sc_main: 0067a3d0
 select_map_entry: 005b73b0
 select_mouse_move: 007138d0

--- a/tests/compare/1220f-32.txt
+++ b/tests/compare/1220f-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0056a3c0
 run_dialog: 008adef0
 run_menus: 0067c5f0
 run_modern_dialog: 008571f0
+save_replay: 006d9190
 sc_main: 0068df40
 select_map_entry: 005bd380
 select_mouse_move: 00719cf0

--- a/tests/compare/1220g-32.txt
+++ b/tests/compare/1220g-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00568b40
 run_dialog: 008d3d80
 run_menus: 006884b0
 run_modern_dialog: 0087e810
+save_replay: 006e3a00
 sc_main: 0069a150
 select_map_entry: 005b2e00
 select_mouse_move: 00721a00

--- a/tests/compare/1220h-32.txt
+++ b/tests/compare/1220h-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0056c3a0
 run_dialog: 008bf390
 run_menus: 0067d0c0
 run_modern_dialog: 00869880
+save_replay: 006d7810
 sc_main: 0068ebc0
 select_map_entry: 005b8180
 select_mouse_move: 00715d50

--- a/tests/compare/1221-32.txt
+++ b/tests/compare/1221-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0057dc80
 run_dialog: 009573c0
 run_menus: 006c15c0
 run_modern_dialog: 008fe200
+save_replay: 00731be0
 sc_main: 006d4a20
 select_map_entry: 005e7350
 select_mouse_move: 0077c880

--- a/tests/compare/1221b-32.txt
+++ b/tests/compare/1221b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0057ade0
 run_dialog: 009148d0
 run_menus: 006af360
 run_modern_dialog: 008bc090
+save_replay: 00726490
 sc_main: 006c1e80
 select_map_entry: 005df6a0
 select_mouse_move: 0076f140

--- a/tests/compare/1221c-32.txt
+++ b/tests/compare/1221c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00573270
 run_dialog: 0092bfd0
 run_menus: 006c3f40
 run_modern_dialog: 008d35f0
+save_replay: 0072fd60
 sc_main: 006d6db0
 select_map_entry: 005df580
 select_mouse_move: 00777c00

--- a/tests/compare/1222-32.txt
+++ b/tests/compare/1222-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00579bb0
 run_dialog: 009220e0
 run_menus: 006b7660
 run_modern_dialog: 008c7460
+save_replay: 00729050
 sc_main: 006cae70
 select_map_entry: 005e7a80
 select_mouse_move: 00773560

--- a/tests/compare/1222b-32.txt
+++ b/tests/compare/1222b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00579e40
 run_dialog: 009209b0
 run_menus: 006aef20
 run_modern_dialog: 008c43d0
+save_replay: 00723990
 sc_main: 006c2d10
 select_map_entry: 005e8ad0
 select_mouse_move: 0076de00

--- a/tests/compare/1222c-32.txt
+++ b/tests/compare/1222c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0057d610
 run_dialog: 009522c0
 run_menus: 006d2750
 run_modern_dialog: 008f7190
+save_replay: 00743ea0
 sc_main: 006e6a50
 select_map_entry: 005ead00
 select_mouse_move: 0078f450

--- a/tests/compare/1222d-32.txt
+++ b/tests/compare/1222d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0057c530
 run_dialog: 0092bc10
 run_menus: 006ba100
 run_modern_dialog: 008cf3c0
+save_replay: 0072baf0
 sc_main: 006ce0c0
 select_map_entry: 005ee770
 select_mouse_move: 00776db0

--- a/tests/compare/1223-32.txt
+++ b/tests/compare/1223-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0056e340
 run_dialog: 009234e0
 run_menus: 006b0e40
 run_modern_dialog: 008c8520
+save_replay: 00724960
 sc_main: 006c4db0
 select_map_entry: 005e1450
 select_mouse_move: 0076f490

--- a/tests/compare/1223_ptr1-32.txt
+++ b/tests/compare/1223_ptr1-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0057a880
 run_dialog: 00915ee0
 run_menus: 006c0ec0
 run_modern_dialog: 008beba0
+save_replay: 0072e730
 sc_main: 006d4790
 select_map_entry: 005e9170
 select_mouse_move: 00774df0

--- a/tests/compare/1223b-32.txt
+++ b/tests/compare/1223b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005750c0
 run_dialog: 0093f850
 run_menus: 006c2910
 run_modern_dialog: 008e3760
+save_replay: 00732eb0
 sc_main: 006d68a0
 select_map_entry: 005eaaa0
 select_mouse_move: 0077ce70

--- a/tests/compare/1223c-32.txt
+++ b/tests/compare/1223c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00579960
 run_dialog: 009706c0
 run_menus: 006c3800
 run_modern_dialog: 009143b0
+save_replay: 0073e540
 sc_main: 006d81d0
 select_map_entry: 005f6a40
 select_mouse_move: 00789e30

--- a/tests/compare/1223d-32.txt
+++ b/tests/compare/1223d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00578960
 run_dialog: 009363f0
 run_menus: 006abf60
 run_modern_dialog: 008d8c60
+save_replay: 00727f80
 sc_main: 006bf860
 select_map_entry: 005dfb80
 select_mouse_move: 007758c0

--- a/tests/compare/1223e-32.txt
+++ b/tests/compare/1223e-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00575f30
 run_dialog: 0095faa0
 run_menus: 006ce230
 run_modern_dialog: 00901fc0
+save_replay: 00744ce0
 sc_main: 006e1c60
 select_map_entry: 005f0510
 select_mouse_move: 0078ce70

--- a/tests/compare/1224-32.txt
+++ b/tests/compare/1224-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00584650
 run_dialog: 00944fb0
 run_menus: 006cf0a0
 run_modern_dialog: 008ea6c0
+save_replay: 00740f00
 sc_main: 006e2750
 select_map_entry: 005f9b70
 select_mouse_move: 00788470

--- a/tests/compare/1224b-32.txt
+++ b/tests/compare/1224b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0057dff0
 run_dialog: 00958a60
 run_menus: 006d2770
 run_modern_dialog: 00901940
+save_replay: 007481b0
 sc_main: 006e6590
 select_map_entry: 005f72f0
 select_mouse_move: 007928c0

--- a/tests/compare/1224c-32.txt
+++ b/tests/compare/1224c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00579b10
 run_dialog: 0090efe0
 run_menus: 006d0fb0
 run_modern_dialog: 008b6a60
+save_replay: 0073fb30
 sc_main: 006e4350
 select_map_entry: 005e8b40
 select_mouse_move: 00787530

--- a/tests/compare/1230a-32.txt
+++ b/tests/compare/1230a-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00582fd0
 run_dialog: 008cbc90
 run_menus: 006a0860
 run_modern_dialog: 00872770
+save_replay: 006f33b0
 sc_main: 006b0790
 select_map_entry: 005eb5c0
 select_mouse_move: 0072c6d0

--- a/tests/compare/1230a-64.txt
+++ b/tests/compare/1230a-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401a85b0
 run_dialog: 1405c2d30
 run_menus: 140325b70
 run_modern_dialog: 14055a630
+save_replay: 140396c80
 sc_main: 140339640
 select_map_entry: 14022baa0
 select_mouse_move: 1403e0830

--- a/tests/compare/1230b-32.txt
+++ b/tests/compare/1230b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0058e8e0
 run_dialog: 008e3d50
 run_menus: 006a18c0
 run_modern_dialog: 0088b9c0
+save_replay: 00706510
 sc_main: 006b18c0
 select_map_entry: 005eef70
 select_mouse_move: 00743dd0

--- a/tests/compare/1230b-64.txt
+++ b/tests/compare/1230b-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 14019be40
 run_dialog: 14058a200
 run_menus: 1402ed2d0
 run_modern_dialog: 140524200
+save_replay: 14035e1c0
 sc_main: 140300ef0
 select_map_entry: 1402121b0
 select_mouse_move: 1403a4b00

--- a/tests/compare/1230c-32.txt
+++ b/tests/compare/1230c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00587ba0
 run_dialog: 008c5b10
 run_menus: 0069af70
 run_modern_dialog: 0086e460
+save_replay: 006f6160
 sc_main: 006ab170
 select_map_entry: 005e4bc0
 select_mouse_move: 00731e60

--- a/tests/compare/1230c-64.txt
+++ b/tests/compare/1230c-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 14019f960
 run_dialog: 1405bc940
 run_menus: 140302e20
 run_modern_dialog: 1405541e0
+save_replay: 140377110
 sc_main: 140316910
 select_map_entry: 1402160b0
 select_mouse_move: 1403c09d0

--- a/tests/compare/1230d-32.txt
+++ b/tests/compare/1230d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00577220
 run_dialog: 008f2fd0
 run_menus: 006b2310
 run_modern_dialog: 0089a950
+save_replay: 007108b0
 sc_main: 006c2450
 select_map_entry: 005eb590
 select_mouse_move: 0074a780

--- a/tests/compare/1230d-64.txt
+++ b/tests/compare/1230d-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401993b0
 run_dialog: 1405b4b60
 run_menus: 140302480
 run_modern_dialog: 14054ce50
+save_replay: 140377280
 sc_main: 140315df0
 select_map_entry: 1402115a0
 select_mouse_move: 1403bfae0

--- a/tests/compare/1230e-32.txt
+++ b/tests/compare/1230e-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00590210
 run_dialog: 00904dc0
 run_menus: 006af370
 run_modern_dialog: 008aa330
+save_replay: 00712e60
 sc_main: 006bf460
 select_map_entry: 005f7470
 select_mouse_move: 0074f2a0

--- a/tests/compare/1230e-64.txt
+++ b/tests/compare/1230e-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401a0db0
 run_dialog: 1405bae40
 run_menus: 14030fe50
 run_modern_dialog: 1405525c0
+save_replay: 1403860c0
 sc_main: 140323a10
 select_map_entry: 140216cc0
 select_mouse_move: 1403ce8f0

--- a/tests/compare/1230f-32.txt
+++ b/tests/compare/1230f-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0057ee30
 run_dialog: 008ca000
 run_menus: 006aec00
 run_modern_dialog: 00872ba0
+save_replay: 00705190
 sc_main: 006be8d0
 select_map_entry: 005ee1d0
 select_mouse_move: 0073cd70

--- a/tests/compare/1230f-64.txt
+++ b/tests/compare/1230f-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 140199760
 run_dialog: 1405a8c80
 run_menus: 1402f6570
 run_modern_dialog: 1405420c0
+save_replay: 1403696a0
 sc_main: 14030a230
 select_map_entry: 140205630
 select_mouse_move: 1403b0810

--- a/tests/compare/1230g-32.txt
+++ b/tests/compare/1230g-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00587380
 run_dialog: 00904f30
 run_menus: 006bba30
 run_modern_dialog: 008ac6e0
+save_replay: 00717330
 sc_main: 006cc290
 select_map_entry: 005f1490
 select_mouse_move: 00750d50

--- a/tests/compare/1230g-64.txt
+++ b/tests/compare/1230g-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401a6da0
 run_dialog: 1405c1400
 run_menus: 140305f30
 run_modern_dialog: 140558440
+save_replay: 14037a430
 sc_main: 140319be0
 select_map_entry: 14021e120
 select_mouse_move: 1403c5840

--- a/tests/compare/1230h-32.txt
+++ b/tests/compare/1230h-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0057e440
 run_dialog: 008f6190
 run_menus: 006ad9e0
 run_modern_dialog: 0089d560
+save_replay: 0070f8a0
 sc_main: 006bd7e0
 select_map_entry: 005e61e0
 select_mouse_move: 00749690

--- a/tests/compare/1230h-64.txt
+++ b/tests/compare/1230h-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401a7b50
 run_dialog: 1405d1bf0
 run_menus: 140318d40
 run_modern_dialog: 140567bb0
+save_replay: 140385c60
 sc_main: 14032c1e0
 select_map_entry: 140229dc0
 select_mouse_move: 1403cc530

--- a/tests/compare/1230i-32.txt
+++ b/tests/compare/1230i-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00584be0
 run_dialog: 00900a30
 run_menus: 006c7a80
 run_modern_dialog: 008a6570
+save_replay: 00726850
 sc_main: 006d7710
 select_map_entry: 005e9af0
 select_mouse_move: 00763380

--- a/tests/compare/1230i-64.txt
+++ b/tests/compare/1230i-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401a71b0
 run_dialog: 1405eb8e0
 run_menus: 140325680
 run_modern_dialog: 140583490
+save_replay: 14039a320
 sc_main: 140338ac0
 select_map_entry: 14022c5e0
 select_mouse_move: 1403e16d0

--- a/tests/compare/1230j-32.txt
+++ b/tests/compare/1230j-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00585dc0
 run_dialog: 008e8930
 run_menus: 006a3d70
 run_modern_dialog: 0088ea30
+save_replay: 007083b0
 sc_main: 006b3660
 select_map_entry: 005e6d30
 select_mouse_move: 00742c20

--- a/tests/compare/1230j-64.txt
+++ b/tests/compare/1230j-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401aac80
 run_dialog: 1405ea9c0
 run_menus: 140332ef0
 run_modern_dialog: 140582550
+save_replay: 14039ef30
 sc_main: 140346590
 select_map_entry: 140226950
 select_mouse_move: 1403e42b0

--- a/tests/compare/12310a-32.txt
+++ b/tests/compare/12310a-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005971a0
 run_dialog: 0098e950
 run_menus: 006ed1e0
 run_modern_dialog: 0092f900
+save_replay: 00756000
 sc_main: 006ffbd0
 select_map_entry: 005fbf50
 select_mouse_move: 007a4c10

--- a/tests/compare/12310a-64.txt
+++ b/tests/compare/12310a-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b5440
 run_dialog: 140617ce0
 run_menus: 14034ede0
 run_modern_dialog: 1405ad640
+save_replay: 1403be5b0
 sc_main: 140363d20
 select_map_entry: 1402312b0
 select_mouse_move: 14041ab70

--- a/tests/compare/12310b-32.txt
+++ b/tests/compare/12310b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a26b0
 run_dialog: 00963420
 run_menus: 006e09b0
 run_modern_dialog: 00906020
+save_replay: 00749020
 sc_main: 006f3680
 select_map_entry: 0060ddd0
 select_mouse_move: 00798c10

--- a/tests/compare/12310b-64.txt
+++ b/tests/compare/12310b-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401ba470
 run_dialog: 14062eb80
 run_menus: 14035ddc0
 run_modern_dialog: 1405c4860
+save_replay: 1403d2b60
 sc_main: 140373970
 select_map_entry: 140237f00
 select_mouse_move: 14042f1b0

--- a/tests/compare/12310c-32.txt
+++ b/tests/compare/12310c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0059c4f0
 run_dialog: 00972100
 run_menus: 006ecb00
 run_modern_dialog: 00913fd0
+save_replay: 007543f0
 sc_main: 006ff7c0
 select_map_entry: 00601690
 select_mouse_move: 007a32e0

--- a/tests/compare/12310c-64.txt
+++ b/tests/compare/12310c-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b3ef0
 run_dialog: 140614230
 run_menus: 14033ab80
 run_modern_dialog: 1405a99e0
+save_replay: 1403b8a10
 sc_main: 14034f500
 select_map_entry: 140227af0
 select_mouse_move: 140415160

--- a/tests/compare/12310d-32.txt
+++ b/tests/compare/12310d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a4230
 run_dialog: 009bd120
 run_menus: 007120f0
 run_modern_dialog: 0095f800
+save_replay: 0077cce0
 sc_main: 00724630
 select_map_entry: 00612360
 select_mouse_move: 007ce460

--- a/tests/compare/12310d-64.txt
+++ b/tests/compare/12310d-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b90c0
 run_dialog: 1406808d0
 run_menus: 14036aab0
 run_modern_dialog: 140615950
+save_replay: 1403e7cf0
 sc_main: 1403803e0
 select_map_entry: 14022fda0
 select_mouse_move: 140445260

--- a/tests/compare/12310e-32.txt
+++ b/tests/compare/12310e-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a2010
 run_dialog: 0096d7c0
 run_menus: 006df490
 run_modern_dialog: 009100c0
+save_replay: 007461f0
 sc_main: 006f1c50
 select_map_entry: 00602f90
 select_mouse_move: 00798630

--- a/tests/compare/12310e-64.txt
+++ b/tests/compare/12310e-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401ae3d0
 run_dialog: 14061a720
 run_menus: 14032d7b0
 run_modern_dialog: 1405b01c0
+save_replay: 1403a8700
 sc_main: 140342690
 select_map_entry: 140225a70
 select_mouse_move: 1404063b0

--- a/tests/compare/12310f-32.txt
+++ b/tests/compare/12310f-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a48f0
 run_dialog: 009a0350
 run_menus: 00706e10
 run_modern_dialog: 009425d0
+save_replay: 0076dea0
 sc_main: 00719ba0
 select_map_entry: 0060dc70
 select_mouse_move: 007be4f0

--- a/tests/compare/12310f-64.txt
+++ b/tests/compare/12310f-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401bcfe0
 run_dialog: 140621a90
 run_menus: 14032fc10
 run_modern_dialog: 1405b7c60
+save_replay: 1403af000
 sc_main: 1403452c0
 select_map_entry: 140232170
 select_mouse_move: 14040c200

--- a/tests/compare/12310g-32.txt
+++ b/tests/compare/12310g-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a6780
 run_dialog: 00975e50
 run_menus: 006f9bb0
 run_modern_dialog: 009184a0
+save_replay: 0075a100
 sc_main: 0070bfc0
 select_map_entry: 00610d70
 select_mouse_move: 007a7e00

--- a/tests/compare/12310g-64.txt
+++ b/tests/compare/12310g-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401baf30
 run_dialog: 14063eea0
 run_menus: 14033e370
 run_modern_dialog: 1405d39e0
+save_replay: 1403b8010
 sc_main: 140353ad0
 select_map_entry: 14022ae20
 select_mouse_move: 1404173b0

--- a/tests/compare/1231a-32.txt
+++ b/tests/compare/1231a-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0058c720
 run_dialog: 0092f9b0
 run_menus: 006c2ee0
 run_modern_dialog: 008d7a40
+save_replay: 00726870
 sc_main: 006d2ce0
 select_map_entry: 005f25f0
 select_mouse_move: 00761ee0

--- a/tests/compare/1231a-64.txt
+++ b/tests/compare/1231a-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401a1490
 run_dialog: 1405a08a0
 run_menus: 1402fe050
 run_modern_dialog: 140539840
+save_replay: 14036fcf0
 sc_main: 140311260
 select_map_entry: 14021aea0
 select_mouse_move: 1403b6d60

--- a/tests/compare/1232a-32.txt
+++ b/tests/compare/1232a-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005991e0
 run_dialog: 0097cfc0
 run_menus: 006ef7e0
 run_modern_dialog: 00913330
+save_replay: 0075f790
 sc_main: 00707830
 select_map_entry: 0060d860
 select_mouse_move: 0079fb20

--- a/tests/compare/1232a-64.txt
+++ b/tests/compare/1232a-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401ab170
 run_dialog: 140608ef0
 run_menus: 1403396c0
 run_modern_dialog: 14058f4a0
+save_replay: 1403b9700
 sc_main: 140355550
 select_map_entry: 14022d900
 select_mouse_move: 140401b30

--- a/tests/compare/1232b-32.txt
+++ b/tests/compare/1232b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00595180
 run_dialog: 00974ab0
 run_menus: 006e8560
 run_modern_dialog: 0090b120
+save_replay: 00753ea0
 sc_main: 007006f0
 select_map_entry: 00607110
 select_mouse_move: 00791600

--- a/tests/compare/1232b-64.txt
+++ b/tests/compare/1232b-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401a84e0
 run_dialog: 1405f3620
 run_menus: 140317e40
 run_modern_dialog: 1405762e0
+save_replay: 140395640
 sc_main: 140333d90
 select_map_entry: 140227190
 select_mouse_move: 1403e0960

--- a/tests/compare/1232c-32.txt
+++ b/tests/compare/1232c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005974c0
 run_dialog: 0095d560
 run_menus: 006f0a30
 run_modern_dialog: 008f4520
+save_replay: 00757620
 sc_main: 00708600
 select_map_entry: 0060e790
 select_mouse_move: 007956d0

--- a/tests/compare/1232c-64.txt
+++ b/tests/compare/1232c-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401ac640
 run_dialog: 1405dfa40
 run_menus: 1403107b0
 run_modern_dialog: 140563bf0
+save_replay: 140392440
 sc_main: 14032c100
 select_map_entry: 140228140
 select_mouse_move: 1403dd8e0

--- a/tests/compare/1232d-32.txt
+++ b/tests/compare/1232d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00592660
 run_dialog: 00966270
 run_menus: 006ef3d0
 run_modern_dialog: 008fb3b0
+save_replay: 0075b7e0
 sc_main: 00707240
 select_map_entry: 00603d30
 select_mouse_move: 00797840

--- a/tests/compare/1232d-64.txt
+++ b/tests/compare/1232d-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b2bb0
 run_dialog: 140611860
 run_menus: 14033a870
 run_modern_dialog: 140597180
+save_replay: 1403b7080
 sc_main: 140356760
 select_map_entry: 140235cf0
 select_mouse_move: 140400090

--- a/tests/compare/1232e-32.txt
+++ b/tests/compare/1232e-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0058dfe0
 run_dialog: 0093ab20
 run_menus: 006d80d0
 run_modern_dialog: 008d19e0
+save_replay: 007430f0
 sc_main: 006ef9e0
 select_map_entry: 005fd7f0
 select_mouse_move: 007820f0

--- a/tests/compare/1232e-64.txt
+++ b/tests/compare/1232e-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b3900
 run_dialog: 1405fbc50
 run_menus: 140322050
 run_modern_dialog: 140581620
+save_replay: 14039e8f0
 sc_main: 14033dc20
 select_map_entry: 14022b8e0
 select_mouse_move: 1403e7c50

--- a/tests/compare/1233a-32.txt
+++ b/tests/compare/1233a-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00597750
 run_dialog: 0099f010
 run_menus: 00701bd0
 run_modern_dialog: 0093df70
+save_replay: 00764270
 sc_main: 007132e0
 select_map_entry: 006100b0
 select_mouse_move: 007b1e90

--- a/tests/compare/1233a-64.txt
+++ b/tests/compare/1233a-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401a5850
 run_dialog: 140618570
 run_menus: 14032de80
 run_modern_dialog: 1405a8360
+save_replay: 1403a9760
 sc_main: 140341ba0
 select_map_entry: 140222d80
 select_mouse_move: 140406610

--- a/tests/compare/1233b-32.txt
+++ b/tests/compare/1233b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00599f70
 run_dialog: 0097e830
 run_menus: 006e6130
 run_modern_dialog: 0091c090
+save_replay: 00749440
 sc_main: 006f7640
 select_map_entry: 0060a580
 select_mouse_move: 00796290

--- a/tests/compare/1233b-64.txt
+++ b/tests/compare/1233b-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401ac9d0
 run_dialog: 14060f200
 run_menus: 140331f70
 run_modern_dialog: 14059f300
+save_replay: 14039fcd0
 sc_main: 140345fb0
 select_map_entry: 1402306e0
 select_mouse_move: 1403f8e70

--- a/tests/compare/1233c-32.txt
+++ b/tests/compare/1233c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0059c9e0
 run_dialog: 00965160
 run_menus: 006e0640
 run_modern_dialog: 009054d0
+save_replay: 00746600
 sc_main: 006f15c0
 select_map_entry: 00604b40
 select_mouse_move: 007958e0

--- a/tests/compare/1233c-64.txt
+++ b/tests/compare/1233c-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b3aa0
 run_dialog: 14062fdb0
 run_menus: 140344b20
 run_modern_dialog: 1405c1e30
+save_replay: 1403c4750
 sc_main: 140358ac0
 select_map_entry: 140232640
 select_mouse_move: 14041f440

--- a/tests/compare/1233d-32.txt
+++ b/tests/compare/1233d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00592e00
 run_dialog: 0098f1a0
 run_menus: 006dde30
 run_modern_dialog: 0092f1c0
+save_replay: 0074a020
 sc_main: 006ef040
 select_map_entry: 00606b80
 select_mouse_move: 00798e80

--- a/tests/compare/1233d-64.txt
+++ b/tests/compare/1233d-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b2690
 run_dialog: 1405e3480
 run_menus: 140322390
 run_modern_dialog: 140575ca0
+save_replay: 140399f20
 sc_main: 140336220
 select_map_entry: 140236e90
 select_mouse_move: 1403f53c0

--- a/tests/compare/1233e-32.txt
+++ b/tests/compare/1233e-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005978c0
 run_dialog: 009539f0
 run_menus: 006d1740
 run_modern_dialog: 008f2ee0
+save_replay: 007304f0
 sc_main: 006e2f70
 select_map_entry: 00605050
 select_mouse_move: 0077b960

--- a/tests/compare/1233e-64.txt
+++ b/tests/compare/1233e-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401af920
 run_dialog: 140610530
 run_menus: 140332330
 run_modern_dialog: 1405a07b0
+save_replay: 1403b4ef0
 sc_main: 140345fb0
 select_map_entry: 140228d80
 select_mouse_move: 14040f320

--- a/tests/compare/1233f-32.txt
+++ b/tests/compare/1233f-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00596720
 run_dialog: 0097e5a0
 run_menus: 006e2f60
 run_modern_dialog: 0091d440
+save_replay: 0074c4d0
 sc_main: 006f48a0
 select_map_entry: 00606160
 select_mouse_move: 0079af00

--- a/tests/compare/1233f-64.txt
+++ b/tests/compare/1233f-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401a9550
 run_dialog: 1405fc630
 run_menus: 14031b580
 run_modern_dialog: 14058cd70
+save_replay: 14039bbf0
 sc_main: 14032f440
 select_map_entry: 1402288e0
 select_mouse_move: 1403f7240

--- a/tests/compare/1233g-32.txt
+++ b/tests/compare/1233g-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005ab4c0
 run_dialog: 0098b480
 run_menus: 006f79b0
 run_modern_dialog: 0092d480
+save_replay: 007589c0
 sc_main: 00708f40
 select_map_entry: 006167c0
 select_mouse_move: 007a5340

--- a/tests/compare/1233g-64.txt
+++ b/tests/compare/1233g-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b80a0
 run_dialog: 1406332f0
 run_menus: 140347b80
 run_modern_dialog: 1405c76b0
+save_replay: 1403bd0e0
 sc_main: 14035c620
 select_map_entry: 14023d590
 select_mouse_move: 140417020

--- a/tests/compare/1233h-32.txt
+++ b/tests/compare/1233h-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a4050
 run_dialog: 00988970
 run_menus: 006eb410
 run_modern_dialog: 009284a0
+save_replay: 00754f80
 sc_main: 006fcd20
 select_map_entry: 006135d0
 select_mouse_move: 007a2ef0

--- a/tests/compare/1233h-64.txt
+++ b/tests/compare/1233h-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401c35b0
 run_dialog: 14060cce0
 run_menus: 140348680
 run_modern_dialog: 14059f650
+save_replay: 1403bcbb0
 sc_main: 14035c5f0
 select_map_entry: 14023c320
 select_mouse_move: 140415b30

--- a/tests/compare/1233i-32.txt
+++ b/tests/compare/1233i-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a7c20
 run_dialog: 00995480
 run_menus: 00702ba0
 run_modern_dialog: 00937430
+save_replay: 0076c620
 sc_main: 00714de0
 select_map_entry: 00614e40
 select_mouse_move: 007b9250

--- a/tests/compare/1234_ptr1-32.txt
+++ b/tests/compare/1234_ptr1-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00595e80
 run_dialog: 00979000
 run_menus: 006f5900
 run_modern_dialog: 0091b2f0
+save_replay: 0075fc20
 sc_main: 00707370
 select_map_entry: 00603f40
 select_mouse_move: 007ae750

--- a/tests/compare/1234_ptr1-64.txt
+++ b/tests/compare/1234_ptr1-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401c1f30
 run_dialog: 14064dd80
 run_menus: 140354700
 run_modern_dialog: 1405e1bf0
+save_replay: 1403cf7f0
 sc_main: 140369060
 select_map_entry: 140246f80
 select_mouse_move: 14042c500

--- a/tests/compare/1234a-32.txt
+++ b/tests/compare/1234a-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a3fa0
 run_dialog: 009bd480
 run_menus: 007022b0
 run_modern_dialog: 0095c890
+save_replay: 0076ac40
 sc_main: 00714340
 select_map_entry: 00610f40
 select_mouse_move: 007bb570

--- a/tests/compare/1234a-64.txt
+++ b/tests/compare/1234a-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401ba210
 run_dialog: 140641650
 run_menus: 1403595a0
 run_modern_dialog: 1405d35b0
+save_replay: 1403d9ed0
 sc_main: 14036e210
 select_map_entry: 1402451f0
 select_mouse_move: 140435c70

--- a/tests/compare/1234b-32.txt
+++ b/tests/compare/1234b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005aac90
 run_dialog: 009852f0
 run_menus: 006ef5b0
 run_modern_dialog: 009273b0
+save_replay: 0075d4a0
 sc_main: 00701970
 select_map_entry: 00611eb0
 select_mouse_move: 007ac3a0

--- a/tests/compare/1234b-64.txt
+++ b/tests/compare/1234b-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b8d00
 run_dialog: 14061ca10
 run_menus: 14033ece0
 run_modern_dialog: 1405ae620
+save_replay: 1403b6640
 sc_main: 140353690
 select_map_entry: 14023b9b0
 select_mouse_move: 140410030

--- a/tests/compare/1234c-32.txt
+++ b/tests/compare/1234c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a0200
 run_dialog: 009a57b0
 run_menus: 007118d0
 run_modern_dialog: 009471d0
+save_replay: 007727d0
 sc_main: 007238e0
 select_map_entry: 00613af0
 select_mouse_move: 007c0710

--- a/tests/compare/1234c-64.txt
+++ b/tests/compare/1234c-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401bbc70
 run_dialog: 140627db0
 run_menus: 14035e2d0
 run_modern_dialog: 1405bccd0
+save_replay: 1403d4620
 sc_main: 1403724f0
 select_map_entry: 140239ec0
 select_mouse_move: 14042d3c0

--- a/tests/compare/1234d-32.txt
+++ b/tests/compare/1234d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005ab490
 run_dialog: 0096aac0
 run_menus: 006efd30
 run_modern_dialog: 0090cc00
+save_replay: 0075ac40
 sc_main: 00701710
 select_map_entry: 0061b520
 select_mouse_move: 007a99a0

--- a/tests/compare/1234d-64.txt
+++ b/tests/compare/1234d-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401bb200
 run_dialog: 14064a200
 run_menus: 1403517f0
 run_modern_dialog: 1405dd810
+save_replay: 1403d2730
 sc_main: 140365e90
 select_map_entry: 14023a350
 select_mouse_move: 14042f890

--- a/tests/compare/1235a-32.txt
+++ b/tests/compare/1235a-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a7570
 run_dialog: 00964f20
 run_menus: 006e9460
 run_modern_dialog: 00907370
+save_replay: 00748ea0
 sc_main: 006fbb30
 select_map_entry: 006134e0
 select_mouse_move: 00796d40

--- a/tests/compare/1235a-64.txt
+++ b/tests/compare/1235a-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b4650
 run_dialog: 140615040
 run_menus: 140337d40
 run_modern_dialog: 1405a6740
+save_replay: 1403a7750
 sc_main: 14034c940
 select_map_entry: 14022f680
 select_mouse_move: 140402a80

--- a/tests/compare/1235b-32.txt
+++ b/tests/compare/1235b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a8820
 run_dialog: 0098e0c0
 run_menus: 006fb3e0
 run_modern_dialog: 0092f760
+save_replay: 00761060
 sc_main: 0070dff0
 select_map_entry: 00612460
 select_mouse_move: 007af3b0

--- a/tests/compare/1235b-64.txt
+++ b/tests/compare/1235b-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b82e0
 run_dialog: 14061da30
 run_menus: 14033d680
 run_modern_dialog: 1405b2630
+save_replay: 1403bcfb0
 sc_main: 140352bf0
 select_map_entry: 140234740
 select_mouse_move: 14041a4d0

--- a/tests/compare/1235c-32.txt
+++ b/tests/compare/1235c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00599080
 run_dialog: 00985f30
 run_menus: 006f6b50
 run_modern_dialog: 00926a40
+save_replay: 0075ff30
 sc_main: 00708d10
 select_map_entry: 005fd440
 select_mouse_move: 007ad210

--- a/tests/compare/1235c-64.txt
+++ b/tests/compare/1235c-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401ad320
 run_dialog: 14062c870
 run_menus: 14033e9c0
 run_modern_dialog: 1405bf4f0
+save_replay: 1403beee0
 sc_main: 140353a80
 select_map_entry: 140227d60
 select_mouse_move: 14041b680

--- a/tests/compare/1235d-32.txt
+++ b/tests/compare/1235d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005aa790
 run_dialog: 009af480
 run_menus: 00713810
 run_modern_dialog: 00951070
+save_replay: 0077a430
 sc_main: 00725f00
 select_map_entry: 0061c440
 select_mouse_move: 007ca8e0

--- a/tests/compare/1235d-64.txt
+++ b/tests/compare/1235d-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b6f30
 run_dialog: 140627350
 run_menus: 14034a4a0
 run_modern_dialog: 1405bba20
+save_replay: 1403bcb10
 sc_main: 14035f960
 select_map_entry: 140235160
 select_mouse_move: 1404170d0

--- a/tests/compare/1235e-32.txt
+++ b/tests/compare/1235e-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a85f0
 run_dialog: 009a0670
 run_menus: 00702d90
 run_modern_dialog: 00941530
+save_replay: 00765fd0
 sc_main: 00715820
 select_map_entry: 006179a0
 select_mouse_move: 007b6f70

--- a/tests/compare/1235e-64.txt
+++ b/tests/compare/1235e-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b2c60
 run_dialog: 140637da0
 run_menus: 140338a60
 run_modern_dialog: 1405cbb50
+save_replay: 1403ad750
 sc_main: 14034d8b0
 select_map_entry: 140233040
 select_mouse_move: 14040b820

--- a/tests/compare/1235f-32.txt
+++ b/tests/compare/1235f-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005953d0
 run_dialog: 0095e370
 run_menus: 006e1150
 run_modern_dialog: 008fe780
+save_replay: 00747b60
 sc_main: 006f3290
 select_map_entry: 005ff1b0
 select_mouse_move: 00796030

--- a/tests/compare/1235f-64.txt
+++ b/tests/compare/1235f-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b25b0
 run_dialog: 1406224c0
 run_menus: 14034e630
 run_modern_dialog: 1405b4320
+save_replay: 1403c5150
 sc_main: 1403630a0
 select_map_entry: 140230940
 select_mouse_move: 14041f160

--- a/tests/compare/1235g-32.txt
+++ b/tests/compare/1235g-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a8390
 run_dialog: 009a03f0
 run_menus: 006ffe70
 run_modern_dialog: 0093ff00
+save_replay: 00766db0
 sc_main: 00712830
 select_map_entry: 00619b40
 select_mouse_move: 007b8a90

--- a/tests/compare/1235g-64.txt
+++ b/tests/compare/1235g-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401c11d0
 run_dialog: 14065ace0
 run_menus: 140359ff0
 run_modern_dialog: 1405ee150
+save_replay: 1403d1ce0
 sc_main: 14036f200
 select_map_entry: 140249270
 select_mouse_move: 14042e8e0

--- a/tests/compare/1235h-32.txt
+++ b/tests/compare/1235h-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a81d0
 run_dialog: 00995240
 run_menus: 006ec220
 run_modern_dialog: 009365e0
+save_replay: 00753b40
 sc_main: 006fe9e0
 select_map_entry: 00612470
 select_mouse_move: 007a46f0

--- a/tests/compare/1235h-64.txt
+++ b/tests/compare/1235h-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b6770
 run_dialog: 14062eff0
 run_menus: 1403455c0
 run_modern_dialog: 1405c2bb0
+save_replay: 1403b9750
 sc_main: 14035aa60
 select_map_entry: 14022f040
 select_mouse_move: 140416560

--- a/tests/compare/1236a-32.txt
+++ b/tests/compare/1236a-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0059f870
 run_dialog: 00981f80
 run_menus: 006fd7e0
 run_modern_dialog: 00923100
+save_replay: 007612b0
 sc_main: 007102d0
 select_map_entry: 00610590
 select_mouse_move: 007b26d0

--- a/tests/compare/1236a-64.txt
+++ b/tests/compare/1236a-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b2460
 run_dialog: 14062b120
 run_menus: 14034aa30
 run_modern_dialog: 1405bea00
+save_replay: 1403bc970
 sc_main: 14035f8c0
 select_map_entry: 14022caf0
 select_mouse_move: 140417ce0

--- a/tests/compare/1236b-32.txt
+++ b/tests/compare/1236b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005b1280
 run_dialog: 009af9e0
 run_menus: 00724400
 run_modern_dialog: 009516a0
+save_replay: 0078bc30
 sc_main: 00736e30
 select_map_entry: 00612d00
 select_mouse_move: 007d9e40

--- a/tests/compare/1236b-64.txt
+++ b/tests/compare/1236b-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b8c30
 run_dialog: 140658a90
 run_menus: 140354990
 run_modern_dialog: 1405ed570
+save_replay: 1403d3fc0
 sc_main: 140369ac0
 select_map_entry: 140233970
 select_mouse_move: 140433a00

--- a/tests/compare/1237a-32.txt
+++ b/tests/compare/1237a-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a0920
 run_dialog: 0099c2f0
 run_menus: 006f7f40
 run_modern_dialog: 0093e090
+save_replay: 00766a20
 sc_main: 0070a6c0
 select_map_entry: 0060da40
 select_mouse_move: 007b7c80

--- a/tests/compare/1237a-64.txt
+++ b/tests/compare/1237a-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b2800
 run_dialog: 14066b1a0
 run_menus: 1403561d0
 run_modern_dialog: 1405fb530
+save_replay: 1403d42b0
 sc_main: 14036b050
 select_map_entry: 140236f80
 select_mouse_move: 140432cb0

--- a/tests/compare/1238a-32.txt
+++ b/tests/compare/1238a-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a97c0
 run_dialog: 009c0f70
 run_menus: 00715930
 run_modern_dialog: 009622c0
+save_replay: 00777420
 sc_main: 007284a0
 select_map_entry: 0060c0e0
 select_mouse_move: 007c4cc0

--- a/tests/compare/1238a-64.txt
+++ b/tests/compare/1238a-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401c3b80
 run_dialog: 1406775a0
 run_menus: 14036c8d0
 run_modern_dialog: 14060a760
+save_replay: 1403e7fe0
 sc_main: 1403823e0
 select_map_entry: 14023cb60
 select_mouse_move: 140445a00

--- a/tests/compare/1238b-32.txt
+++ b/tests/compare/1238b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005affa0
 run_dialog: 009b33a0
 run_menus: 0071ebe0
 run_modern_dialog: 00953440
+save_replay: 00788110
 sc_main: 00731b20
 select_map_entry: 0061aa70
 select_mouse_move: 007d7de0

--- a/tests/compare/1238b-64.txt
+++ b/tests/compare/1238b-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401c0040
 run_dialog: 14066e640
 run_menus: 14035b4b0
 run_modern_dialog: 1406023f0
+save_replay: 1403d81a0
 sc_main: 140370e30
 select_map_entry: 140241ad0
 select_mouse_move: 1404359a0

--- a/tests/compare/1238c-32.txt
+++ b/tests/compare/1238c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a7730
 run_dialog: 0099c2f0
 run_menus: 006f3590
 run_modern_dialog: 0093d6d0
+save_replay: 007592f0
 sc_main: 00705a30
 select_map_entry: 00610ad0
 select_mouse_move: 007a7aa0

--- a/tests/compare/1238c-64.txt
+++ b/tests/compare/1238c-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401bb040
 run_dialog: 140632860
 run_menus: 140343980
 run_modern_dialog: 1405c5cc0
+save_replay: 1403b9ee0
 sc_main: 140358bc0
 select_map_entry: 14023b0b0
 select_mouse_move: 140415af0

--- a/tests/compare/1238d-32.txt
+++ b/tests/compare/1238d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0089bfd0
 run_dialog: 008d6080
 run_menus: 006385c0
 run_modern_dialog: 006da7d0
+save_replay: 00771550
 sc_main: 00541010
 select_map_entry: 00821fd0
 select_mouse_move: 007c2240

--- a/tests/compare/1238d-64.txt
+++ b/tests/compare/1238d-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 14052b360
 run_dialog: 14056d5c0
 run_menus: 140263c90
 run_modern_dialog: 1403151e0
+save_replay: 1403be8f0
 sc_main: 14015a940
 select_map_entry: 140497d80
 select_mouse_move: 1404331c0

--- a/tests/compare/1238e-32.txt
+++ b/tests/compare/1238e-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00899280
 run_dialog: 008cf2c0
 run_menus: 00631d70
 run_modern_dialog: 006c2fe0
+save_replay: 00752d80
 sc_main: 005456a0
 select_map_entry: 00817960
 select_mouse_move: 007c9960

--- a/tests/compare/1238f-32.txt
+++ b/tests/compare/1238f-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0059e9e0
 run_dialog: 00988c40
 run_menus: 006f2e90
 run_modern_dialog: 0092aa70
+save_replay: 0075ad20
 sc_main: 00705e30
 select_map_entry: 00606330
 select_mouse_move: 007a9ad0

--- a/tests/compare/1238f-64.txt
+++ b/tests/compare/1238f-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401c0b40
 run_dialog: 14062d250
 run_menus: 1403402c0
 run_modern_dialog: 1405c2700
+save_replay: 1403b4c50
 sc_main: 1403558e0
 select_map_entry: 14023c850
 select_mouse_move: 140413180

--- a/tests/compare/1239a-32.txt
+++ b/tests/compare/1239a-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 0059b1e0
 run_dialog: 0099e880
 run_menus: 006fc060
 run_modern_dialog: 009400a0
+save_replay: 00765dd0
 sc_main: 0070ea50
 select_map_entry: 0060d7d0
 select_mouse_move: 007b54d0

--- a/tests/compare/1239a-64.txt
+++ b/tests/compare/1239a-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401ba790
 run_dialog: 1406266b0
 run_menus: 140348c10
 run_modern_dialog: 1405b9f20
+save_replay: 1403c5d60
 sc_main: 14035d5f0
 select_map_entry: 140232ae0
 select_mouse_move: 140420ea0

--- a/tests/compare/1239b-32.txt
+++ b/tests/compare/1239b-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 00593b30
 run_dialog: 00982eb0
 run_menus: 006f59a0
 run_modern_dialog: 00924b20
+save_replay: 0075cc10
 sc_main: 00708680
 select_map_entry: 005fd940
 select_mouse_move: 007ac320

--- a/tests/compare/1239b-64.txt
+++ b/tests/compare/1239b-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b4e70
 run_dialog: 140625560
 run_menus: 14034c4d0
 run_modern_dialog: 1405b93f0
+save_replay: 1403c3970
 sc_main: 140361350
 select_map_entry: 1402337e0
 select_mouse_move: 14041e020

--- a/tests/compare/1239c-32.txt
+++ b/tests/compare/1239c-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a66e0
 run_dialog: 00960bd0
 run_menus: 006dffb0
 run_modern_dialog: 00901700
+save_replay: 007424a0
 sc_main: 006f2c60
 select_map_entry: 006015a0
 select_mouse_move: 00791230

--- a/tests/compare/1239c-64.txt
+++ b/tests/compare/1239c-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401ace40
 run_dialog: 1405f53e0
 run_menus: 1403222b0
 run_modern_dialog: 14058b250
+save_replay: 14039e6a0
 sc_main: 1403377e0
 select_map_entry: 140228ec0
 select_mouse_move: 1403f96d0

--- a/tests/compare/1239d-32.txt
+++ b/tests/compare/1239d-32.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 005a56a0
 run_dialog: 00987200
 run_menus: 006f8dd0
 run_modern_dialog: 009277b0
+save_replay: 00761ae0
 sc_main: 0070b3b0
 select_map_entry: 006075b0
 select_mouse_move: 007af3c0

--- a/tests/compare/1239d-64.txt
+++ b/tests/compare/1239d-64.txt
@@ -215,6 +215,7 @@ reveal_unit_area: 1401b5b60
 run_dialog: 140616770
 run_menus: 14032b430
 run_modern_dialog: 1405ab9a0
+save_replay: 1403a4d40
 sc_main: 140340b90
 select_map_entry: 14022d120
 select_mouse_move: 140401b20

--- a/tests/everything.rs
+++ b/tests/everything.rs
@@ -1625,7 +1625,7 @@ fn test_nongeneric<'e, E: ExecutionState<'e>>(
                 LookupSoundId | SFileOpenFileEx | SFileReadFileEx | SFileCloseFile |
                 LoadConsoles | InitConsoles | GetUiConsoles | GetStatResIconsDdsGrp |
                 GetUnitSkin | JoinCustomGame | FindFileWithCrc | ForFilesInDir |
-                SimpleFileMatchCallback | GetLocales | InitGameMap => continue,
+                SimpleFileMatchCallback | GetLocales | InitGameMap | SaveReplay => continue,
             _ => (),
         }
         assert!(result.is_some(), "Missing {}", addr.name());
@@ -2320,6 +2320,16 @@ fn test_nongeneric<'e, E: ExecutionState<'e>>(
         assert!(step_bullet_frame.is_none());
     } else {
         assert!(step_bullet_frame.is_some());
+    }
+
+    // save_replay was inlined from 1.20.7 until 1.20.11 (after that it had more callers so it was
+    // never inlined)
+    let save_replay = analysis.save_replay();
+    if minor_version == 20 && matches!(patch_version, 7..11)
+    {
+        assert!(save_replay.is_none());
+    } else {
+        assert!(save_replay.is_some());
     }
 
     // flingy_update_target_dir was inlined to bullet movement in all 1.22 patches


### PR DESCRIPTION
Newer versions take a lot less work because they added a unique string reference, but for older versions I had to come at it from a layer up.

Still missing a few exe's so those dumps are missing, but it should work for all of them.